### PR TITLE
fixed: reading series info from matroska tags only reads first episode index instead of all

### DIFF
--- a/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.cs
@@ -110,8 +110,11 @@ namespace MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor
       if (extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER] != null)
       {
         int episodeNum;
-        if (int.TryParse(extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER].FirstOrDefault(), out episodeNum))
-          seriesInfo.EpisodeNumbers.Add(episodeNum);
+
+        foreach (string s in extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER])
+          if (int.TryParse(s, out episodeNum))
+            if (!seriesInfo.EpisodeNumbers.Contains(episodeNum))
+              seriesInfo.EpisodeNumbers.Add(episodeNum);
       }
       return seriesInfo;
     }


### PR DESCRIPTION
trivial change, ready to merge.

if !Contains(episodeNum) [1](https://github.com/MediaPortal/MediaPortal-2/blob/987bf531205cc3c9a17ebccbdce4a6f8cde9a77b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.cs#L116) was added to workaround duplicated tags in Matroska files

before:
![20130225_215926](https://f.cloud.github.com/assets/601866/194355/905b4a82-7fa7-11e2-85a4-9270e270268e.png)
after:
![20130225_220852](https://f.cloud.github.com/assets/601866/194356/92629e70-7fa7-11e2-8a81-7b5d9dd3cb52.png)
