### PR TITLE
Rework matroska series matcher

### DIFF
--- a/MediaPortal/Source/Extensions/MetadataExtractors/MatroskaLib/MatroskaConsts.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MatroskaLib/MatroskaConsts.cs
@@ -28,6 +28,8 @@ namespace MediaPortal.Extensions.MetadataExtractors.MatroskaLib
 {
   public class MatroskaConsts
   {
+    public static string[] MATROSKA_VIDEO_EXTENSIONS = new[] { ".mkv", ".mk3d" };
+
     // Tags are constructed by using TargetTypeValue (i.e. 70) and the name of the <Simple> tag (i.e. TITLE).
     public const string TAG_SERIES_TITLE = "70.TITLE";
     public const string TAG_SERIES_GENRE = "70.GENRE";
@@ -41,6 +43,8 @@ namespace MediaPortal.Extensions.MetadataExtractors.MatroskaLib
     public const string TAG_EPISODE_YEAR = "50.DATE_RELEASED";
     public const string TAG_EPISODE_NUMBER = "50.PART_NUMBER";
     public const string TAG_SIMPLE_TITLE = "TITLE";
+
+    public const string TAG_MOVIE_IMDB_ID = "50.IMDB";
 
     public static Dictionary<string, IList<string>> DefaultTags
     {
@@ -58,6 +62,7 @@ namespace MediaPortal.Extensions.MetadataExtractors.MatroskaLib
             {TAG_EPISODE_SUMMARY, null}, // Episode summary
             {TAG_EPISODE_YEAR, null}, // Episode year
             {TAG_EPISODE_NUMBER, null}, // Episode number
+            {TAG_MOVIE_IMDB_ID, null}, // movie imdb id
             {TAG_ACTORS, null}, // Actor(s)
             {TAG_SIMPLE_TITLE, null} // File title
           };

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/Matchers/ImdbIdMatcher.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/Matchers/ImdbIdMatcher.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (C) 2007-2013 Team MediaPortal
+#region Copyright (C) 2007-2013 Team MediaPortal
 
 /*
     Copyright (C) 2007-2013 Team MediaPortal
@@ -24,7 +24,7 @@
 
 using System.Text.RegularExpressions;
 
-namespace MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor
+namespace MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor.Matchers
 {
   /// <summary>
   /// <see cref="ImdbIdMatcher"/> tries to match IMDB ids from folder or filenames using regular expressions.

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/Matchers/MatroskaMatcher.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/Matchers/MatroskaMatcher.cs
@@ -1,0 +1,65 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MediaPortal.Extensions.MetadataExtractors.MatroskaLib;
+using MediaPortal.Utilities;
+
+namespace MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor.Matchers
+{
+  /// <summary>
+  /// <see cref="MatroskaMatcher"/> tries to read a valid IMDB id from tags of Matroska files.
+  /// </summary>
+  public class MatroskaMatcher
+  {
+    public static bool TryMatchImdbId(string folderOrFileName, out string imdbId)
+    {
+      string extensionLower = StringUtils.TrimToEmpty(Path.GetExtension(folderOrFileName)).ToLower();
+      if (!MatroskaConsts.MATROSKA_VIDEO_EXTENSIONS.Contains(extensionLower))
+      {
+        imdbId = null;
+        return false;
+      }
+
+      MatroskaInfoReader mkvReader = new MatroskaInfoReader(folderOrFileName);
+      // Add keys to be extracted to tags dictionary, matching results will returned as value
+      Dictionary<string, IList<string>> tagsToExtract = MatroskaConsts.DefaultTags;
+      mkvReader.ReadTags(tagsToExtract);
+
+      if (tagsToExtract[MatroskaConsts.TAG_MOVIE_IMDB_ID] != null)
+      {
+        foreach (string candidate in tagsToExtract[MatroskaConsts.TAG_MOVIE_IMDB_ID])
+        {
+          if (ImdbIdMatcher.TryMatchImdbId(candidate, out imdbId))
+            return true;
+        }
+      }
+
+      imdbId = null;
+      return false;
+    }
+  }
+}

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/Matchers/NfoReader.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/Matchers/NfoReader.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright (C) 2007-2013 Team MediaPortal
+#region Copyright (C) 2007-2013 Team MediaPortal
 
 /*
     Copyright (C) 2007-2013 Team MediaPortal
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using MediaPortal.Common.ResourceAccess;
 
-namespace MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor
+namespace MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor.Matchers
 {
   /// <summary>
   /// <see cref="NfoReader"/> tries to read a valid IMDB id from additional .nfo or .txt files.

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.cs
@@ -32,6 +32,7 @@ using MediaPortal.Common.MediaManagement.DefaultItemAspects;
 using MediaPortal.Common.MediaManagement.Helpers;
 using MediaPortal.Common.ResourceAccess;
 using MediaPortal.Common.Services.ResourceAccess.StreamedResourceToLocalFsAccessBridge;
+using MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor.Matchers;
 using MediaPortal.Extensions.OnlineLibraries;
 using MediaPortal.Extensions.OnlineLibraries.TheMovieDB;
 
@@ -138,7 +139,8 @@ namespace MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor
         string imdbId;
         if (MediaItemAspect.TryGetAttribute(extractedAspectData, MovieAspect.ATTR_IMDB_ID, out imdbId) ||
           pathsToTest.Any(path => ImdbIdMatcher.TryMatchImdbId(path, out imdbId)) ||
-          NfoReader.TryMatchImdbId(lfsra, out imdbId))
+          NfoReader.TryMatchImdbId(lfsra, out imdbId) ||
+          MatroskaMatcher.TryMatchImdbId(lfsra.LocalFileSystemPath, out imdbId))
           movieInfo.ImdbId = imdbId;
 
         // Also test the full path year, using a dummy. This is useful if the path contains the real name and year.

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.csproj
@@ -57,8 +57,9 @@
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="FanartProvider\MovieFanartProvider.cs" />
-    <Compile Include="ImdbIdMatcher.cs" />
-    <Compile Include="NfoReader.cs" />
+    <Compile Include="Matchers\ImdbIdMatcher.cs" />
+    <Compile Include="Matchers\MatroskaMatcher.cs" />
+    <Compile Include="Matchers\NfoReader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MovieMetadataExtractor.cs" />
   </ItemGroup>
@@ -79,6 +80,10 @@
     <ProjectReference Include="..\..\..\Core\MediaPortal.Utilities\MediaPortal.Utilities.csproj">
       <Project>{4FE7B8AE-1330-424A-91A1-C68D7ABF9CB8}</Project>
       <Name>MediaPortal.Utilities</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MatroskaLib\MatroskaLib.csproj">
+      <Project>{0DCFE91A-60DE-42BF-A5F9-A925AA45ECD4}</Project>
+      <Name>MatroskaLib</Name>
     </ProjectReference>
     <ProjectReference Include="..\OnlineLibraries\OnlineLibraries.csproj">
       <Project>{DCA4D19E-75F4-4A8A-B70A-F3F4291DC62B}</Project>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/NameMatchers/MatroskaMatcher.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/NameMatchers/MatroskaMatcher.cs
@@ -1,0 +1,118 @@
+﻿#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MediaPortal.Common.MediaManagement;
+using MediaPortal.Common.MediaManagement.DefaultItemAspects;
+using MediaPortal.Common.MediaManagement.Helpers;
+using MediaPortal.Extensions.MetadataExtractors.MatroskaLib;
+using MediaPortal.Utilities;
+
+namespace MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor.NameMatchers
+{
+  /// <summary>
+  /// <see cref="MatroskaMatcher"/> tries to read series, season and episode metadata from matroska files.
+  /// </summary>
+  public class MatroskaMatcher
+  {
+    /// <summary>
+    /// Tries to match series by reading matroska tags from <paramref name="folderOrFileName"/>.
+    /// </summary>
+    /// <param name="folderOrFileName">Full path to file</param>
+    /// <param name="seriesInfo">Returns the parsed SeriesInfo</param>
+    /// <param name="extractedAspectData">Dictionary containing a mapping of media item aspect ids to
+    /// already present media item aspects, this metadata extractor should edit. If a media item aspect is not present
+    /// in this dictionary but found by this metadata extractor, it will add it to the dictionary.</param>
+    /// <returns><c>true</c> if successful.</returns>
+    public bool MatchSeries(string folderOrFileName, out SeriesInfo seriesInfo, ref IDictionary<Guid, MediaItemAspect> extractedAspectData)
+    {
+      string extensionLower = StringUtils.TrimToEmpty(Path.GetExtension(folderOrFileName)).ToLower();
+
+      if (!MatroskaConsts.MATROSKA_VIDEO_EXTENSIONS.Contains(extensionLower))
+      {
+        seriesInfo = null;
+        return false;
+      }
+
+      MatroskaInfoReader mkvReader = new MatroskaInfoReader(folderOrFileName);
+      // Add keys to be extracted to tags dictionary, matching results will returned as value
+      Dictionary<string, IList<string>> tagsToExtract = MatroskaConsts.DefaultTags;
+      mkvReader.ReadTags(tagsToExtract);
+
+      string title = string.Empty;
+      IList<string> tags = tagsToExtract[MatroskaConsts.TAG_SIMPLE_TITLE];
+      if (tags != null)
+        title = tags.FirstOrDefault();
+
+      if (!string.IsNullOrEmpty(title))
+        MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_TITLE, title);
+
+      string yearCandidate = null;
+      tags = tagsToExtract[MatroskaConsts.TAG_EPISODE_YEAR] ?? tagsToExtract[MatroskaConsts.TAG_SEASON_YEAR];
+      if (tags != null)
+        yearCandidate = (tags.FirstOrDefault() ?? string.Empty).Substring(0, 4);
+
+      int year;
+      if (int.TryParse(yearCandidate, out year))
+        MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_RECORDINGTIME, new DateTime(year, 1, 1));
+
+      tags = tagsToExtract[MatroskaConsts.TAG_EPISODE_SUMMARY];
+      string plot = tags != null ? tags.FirstOrDefault() : string.Empty;
+      if (!string.IsNullOrEmpty(plot))
+        MediaItemAspect.SetAttribute(extractedAspectData, VideoAspect.ATTR_STORYPLOT, plot);
+
+      // Series and episode handling. Prefer information from tags.
+      seriesInfo = GetSeriesFromTags(tagsToExtract);
+
+      return true;
+    }
+
+    protected SeriesInfo GetSeriesFromTags(IDictionary<string, IList<string>> extractedTags)
+    {
+      SeriesInfo seriesInfo = new SeriesInfo();
+      if (extractedTags[MatroskaConsts.TAG_EPISODE_TITLE] != null)
+        seriesInfo.Episode = extractedTags[MatroskaConsts.TAG_EPISODE_TITLE].FirstOrDefault();
+
+      if (extractedTags[MatroskaConsts.TAG_SERIES_TITLE] != null)
+        seriesInfo.Series = extractedTags[MatroskaConsts.TAG_SERIES_TITLE].FirstOrDefault();
+
+      if (extractedTags[MatroskaConsts.TAG_SEASON_NUMBER] != null)
+        int.TryParse(extractedTags[MatroskaConsts.TAG_SEASON_NUMBER].FirstOrDefault(), out seriesInfo.SeasonNumber);
+
+      if (extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER] != null)
+      {
+        int episodeNum;
+
+        foreach (string s in extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER])
+          if (int.TryParse(s, out episodeNum))
+            if (!seriesInfo.EpisodeNumbers.Contains(episodeNum))
+              seriesInfo.EpisodeNumbers.Add(episodeNum);
+      }
+      return seriesInfo;
+    }
+  }
+}

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.cs
@@ -24,8 +24,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using MediaPortal.Common;
 using MediaPortal.Common.Logging;
 using MediaPortal.Common.MediaManagement;
@@ -33,10 +31,8 @@ using MediaPortal.Common.MediaManagement.DefaultItemAspects;
 using MediaPortal.Common.MediaManagement.Helpers;
 using MediaPortal.Common.ResourceAccess;
 using MediaPortal.Common.Services.ResourceAccess.StreamedResourceToLocalFsAccessBridge;
-using MediaPortal.Extensions.MetadataExtractors.MatroskaLib;
 using MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor.NameMatchers;
 using MediaPortal.Extensions.OnlineLibraries;
-using MediaPortal.Utilities;
 
 namespace MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor
 {
@@ -95,68 +91,13 @@ namespace MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor
 
     #region Protected methods
 
-    protected SeriesInfo GetSeriesFromTags(IDictionary<string, IList<string>> extractedTags)
-    {
-      SeriesInfo seriesInfo = new SeriesInfo();
-      if (extractedTags[MatroskaConsts.TAG_EPISODE_TITLE] != null)
-        seriesInfo.Episode = extractedTags[MatroskaConsts.TAG_EPISODE_TITLE].FirstOrDefault();
-
-      if (extractedTags[MatroskaConsts.TAG_SERIES_TITLE] != null)
-        seriesInfo.Series = extractedTags[MatroskaConsts.TAG_SERIES_TITLE].FirstOrDefault();
-
-      if (extractedTags[MatroskaConsts.TAG_SEASON_NUMBER] != null)
-        int.TryParse(extractedTags[MatroskaConsts.TAG_SEASON_NUMBER].FirstOrDefault(), out seriesInfo.SeasonNumber);
-
-      if (extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER] != null)
-      {
-        int episodeNum;
-
-        foreach (string s in extractedTags[MatroskaConsts.TAG_EPISODE_NUMBER])
-          if (int.TryParse(s, out episodeNum))
-            seriesInfo.EpisodeNumbers.Add(episodeNum);
-      }
-      return seriesInfo;
-    }
-
     protected bool ExtractSeriesData(string localFsResourcePath, IDictionary<Guid, MediaItemAspect> extractedAspectData)
     {
       SeriesInfo seriesInfo = null;
 
-      string extensionUpper = StringUtils.TrimToEmpty(Path.GetExtension(localFsResourcePath)).ToUpper();
-
       // Try to get extended information out of matroska files)
-      if (extensionUpper == ".MKV" || extensionUpper == ".MK3D")
-      {
-        MatroskaInfoReader mkvReader = new MatroskaInfoReader(localFsResourcePath);
-        // Add keys to be extracted to tags dictionary, matching results will returned as value
-        Dictionary<string, IList<string>> tagsToExtract = MatroskaConsts.DefaultTags;
-        mkvReader.ReadTags(tagsToExtract);
-
-        string title = string.Empty;
-        IList<string> tags = tagsToExtract[MatroskaConsts.TAG_SIMPLE_TITLE];
-        if (tags != null)
-          title = tags.FirstOrDefault();
-
-        if (!string.IsNullOrEmpty(title))
-          MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_TITLE, title);
-
-        string yearCandidate = null;
-        tags = tagsToExtract[MatroskaConsts.TAG_EPISODE_YEAR] ?? tagsToExtract[MatroskaConsts.TAG_SEASON_YEAR];
-        if (tags != null)
-          yearCandidate = (tags.FirstOrDefault() ?? string.Empty).Substring(0, 4);
-
-        int year;
-        if (int.TryParse(yearCandidate, out year))
-          MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_RECORDINGTIME, new DateTime(year, 1, 1));
-
-        tags = tagsToExtract[MatroskaConsts.TAG_EPISODE_SUMMARY];
-        string plot = tags != null ? tags.FirstOrDefault() : string.Empty;
-        if (!string.IsNullOrEmpty(plot))
-          MediaItemAspect.SetAttribute(extractedAspectData, VideoAspect.ATTR_STORYPLOT, plot);
-
-        // Series and episode handling. Prefer information from tags.
-        seriesInfo = GetSeriesFromTags(tagsToExtract);
-      }
+      MatroskaMatcher matroskaMatcher = new MatroskaMatcher();
+      matroskaMatcher.MatchSeries(localFsResourcePath, out seriesInfo, ref extractedAspectData);
 
       // If now information from mkv were found, try name matching
       if (seriesInfo == null || !seriesInfo.IsCompleteMatch)

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.csproj
@@ -59,6 +59,7 @@
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="FanartProvider\SeriesFanartProvider.cs" />
+    <Compile Include="NameMatchers\MatroskaMatcher.cs" />
     <Compile Include="NameMatchers\SeriesMatcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SeriesMetadataExtractor.cs" />

--- a/MediaPortal/Source/Extensions/MetadataExtractors/VideoMetadataExtractor/VideoMetadataExtractor.cs
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/VideoMetadataExtractor/VideoMetadataExtractor.cs
@@ -262,48 +262,47 @@ namespace MediaPortal.Extensions.MetadataExtractors.VideoMetadataExtractor
 
     protected void ExtractMatroskaTags(string localFsResourcePath, IDictionary<Guid, MediaItemAspect> extractedAspectData, bool forceQuickMode)
     {
-      string extensionUpper = StringUtils.TrimToEmpty(Path.GetExtension(localFsResourcePath)).ToUpper();
+      string extensionLower = StringUtils.TrimToEmpty(Path.GetExtension(localFsResourcePath)).ToLower();
+      if (!MatroskaConsts.MATROSKA_VIDEO_EXTENSIONS.Contains(extensionLower))
+        return;
 
       // Try to get extended information out of matroska files)
-      if (extensionUpper == ".MKV" || extensionUpper == ".MK3D")
-      {
-        MatroskaInfoReader mkvReader = new MatroskaInfoReader(localFsResourcePath);
-        // Add keys to be extracted to tags dictionary, matching results will returned as value
-        Dictionary<string, IList<string>> tagsToExtract = MatroskaConsts.DefaultTags;
-        mkvReader.ReadTags(tagsToExtract);
+      MatroskaInfoReader mkvReader = new MatroskaInfoReader(localFsResourcePath);
+      // Add keys to be extracted to tags dictionary, matching results will returned as value
+      Dictionary<string, IList<string>> tagsToExtract = MatroskaConsts.DefaultTags;
+      mkvReader.ReadTags(tagsToExtract);
 
-        string title = string.Empty;
-        IList<string> tags = tagsToExtract[MatroskaConsts.TAG_SIMPLE_TITLE];
-        if (tags != null)
-          title = tags.FirstOrDefault();
-        if (!string.IsNullOrEmpty(title))
-          MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_TITLE, title);
+      string title = string.Empty;
+      IList<string> tags = tagsToExtract[MatroskaConsts.TAG_SIMPLE_TITLE];
+      if (tags != null)
+        title = tags.FirstOrDefault();
+      if (!string.IsNullOrEmpty(title))
+        MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_TITLE, title);
 
-        int year;
-        string yearCandidate = null;
-        tags = tagsToExtract[MatroskaConsts.TAG_EPISODE_YEAR] ?? tagsToExtract[MatroskaConsts.TAG_SEASON_YEAR];
-        if (tags != null)
-          yearCandidate = (tags.FirstOrDefault() ?? string.Empty).Substring(0, 4);
+      int year;
+      string yearCandidate = null;
+      tags = tagsToExtract[MatroskaConsts.TAG_EPISODE_YEAR] ?? tagsToExtract[MatroskaConsts.TAG_SEASON_YEAR];
+      if (tags != null)
+        yearCandidate = (tags.FirstOrDefault() ?? string.Empty).Substring(0, 4);
 
-        if (int.TryParse(yearCandidate, out year))
-          MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_RECORDINGTIME, new DateTime(year, 1, 1));
+      if (int.TryParse(yearCandidate, out year))
+        MediaItemAspect.SetAttribute(extractedAspectData, MediaAspect.ATTR_RECORDINGTIME, new DateTime(year, 1, 1));
 
-        tags = tagsToExtract[MatroskaConsts.TAG_SERIES_GENRE];
-        if (tags != null)
-          MediaItemAspect.SetCollectionAttribute(extractedAspectData, VideoAspect.ATTR_GENRES, tags);
+      tags = tagsToExtract[MatroskaConsts.TAG_SERIES_GENRE];
+      if (tags != null)
+        MediaItemAspect.SetCollectionAttribute(extractedAspectData, VideoAspect.ATTR_GENRES, tags);
 
-        IEnumerable<string> actors;
-        // Combine series actors and episode actors if both are available
-        var tagSeriesActors = tagsToExtract[MatroskaConsts.TAG_SERIES_ACTORS];
-        var tagActors = tagsToExtract[MatroskaConsts.TAG_ACTORS];
-        if (tagSeriesActors != null && tagActors != null)
-          actors = tagSeriesActors.Union(tagActors);
-        else
-          actors = tagSeriesActors ?? tagActors;
+      IEnumerable<string> actors;
+      // Combine series actors and episode actors if both are available
+      var tagSeriesActors = tagsToExtract[MatroskaConsts.TAG_SERIES_ACTORS];
+      var tagActors = tagsToExtract[MatroskaConsts.TAG_ACTORS];
+      if (tagSeriesActors != null && tagActors != null)
+        actors = tagSeriesActors.Union(tagActors);
+      else
+        actors = tagSeriesActors ?? tagActors;
 
-        if (actors != null)
-          MediaItemAspect.SetCollectionAttribute(extractedAspectData, VideoAspect.ATTR_ACTORS, actors);
-      }
+      if (actors != null)
+        MediaItemAspect.SetCollectionAttribute(extractedAspectData, VideoAspect.ATTR_ACTORS, actors);
     }
 
     protected void ExtractMp4Tags(string localFsResourcePath, IDictionary<Guid, MediaItemAspect> extractedAspectData, bool forceQuickMode)


### PR DESCRIPTION
Includes pull request #6 .

[x] SeriesMDE: Moved matroska tag reading into separate class
[x] MovieMDE: Moved ImdbMatcher & NfoReader into subfolder "Matchers"
[x] MovieMDE: Added reading of IMDB id from matroska tags
[x] MovieMDE: Dependency to MatroskaLib was already set in plugin.xml
[x] SeriesMDE & VideoMDE: Moved matroska file extensions into static array in MatroskaConsts
