### PR TITLE
changed msi output directory

### DIFF
--- a/MediaPortal/Setup/MP2-Setup/MP2-Setup.wixproj
+++ b/MediaPortal/Setup/MP2-Setup/MP2-Setup.wixproj
@@ -12,7 +12,7 @@
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\Bin\MP2-Setup\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug;SourceClientPlugins=$(ProjectDir)..\..\Bin\MP2-Client\bin\x86\Release\Plugins;SourceServerPlugins=$(ProjectDir)..\..\Bin\MP2-Server\bin\x86\Release\Plugins</DefineConstants>
     <SuppressValidation>False</SuppressValidation>
@@ -22,7 +22,7 @@
     <LinkerAdditionalOptions>-sval</LinkerAdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\Bin\MP2-Setup\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>SourceClientPlugins=$(ProjectDir)..\..\Bin\MP2-Client\bin\x86\Release\Plugins;SourceServerPlugins=$(ProjectDir)..\..\Bin\MP2-Server\bin\x86\Release\Plugins</DefineConstants>
     <SuppressIces>ICE60;ICE80</SuppressIces>
@@ -114,11 +114,11 @@
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <PropertyGroup>
-    <PostBuildEvent />
-  </PropertyGroup>
-  <PropertyGroup>
     <PreBuildEvent>"$(WIX)bin\heat.exe" dir "$(ProjectDir)..\..\Bin\MP2-Client\bin\x86\Release\Plugins" -cg ClientPlugins -gg -scom -sreg -sfrag -svb6 -srd -dr CLIENT.PLUGINS.FOLDER -var var.SourceClientPlugins -template fragment -t $(ProjectDir)xslt\ClientFeatures.xslt -out "$(ProjectDir)Features\ClientFeatures.wxs"
 "$(WIX)bin\heat.exe" dir "$(ProjectDir)..\..\Bin\MP2-Server\bin\x86\Release\Plugins" -cg ServerPlugins -gg -scom -sreg -sfrag -svb6 -srd -dr SERVER.PLUGINS.FOLDER -var var.SourceServerPlugins -template fragment -t $(ProjectDir)xslt\ServerFeatures.xslt -out "$(ProjectDir)Features\ServerFeatures.wxs"</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent />
   </PropertyGroup>
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
This changes the output directory of the MSI-setup to the \bin\MP2-Setup directory instead of the currently used subdir in \Setup\MP2-Setup\bin etc.

Compiling instructions have been updated in wiki: http://wiki.team-mediaportal.com/2_MEDIAPORTAL_2/Contribute/Development/Compiling

@gheitmann 
Changes required for the build server are documented in wiki as well: http://wiki.team-mediaportal.com/User:chefkoch/MediaPortal_2/BuildChanges/2_Location_of_*.MSI
