### PR TITLE
fixed xml schemas (dtd & xsd) for the language file xml format

### DIFF
--- a/MediaPortal/Resources/DTDs/language.dtd
+++ b/MediaPortal/Resources/DTDs/language.dtd
@@ -1,12 +1,5 @@
-<!ELEMENT Language (Section)*>
-<!ATTLIST Language
-          Name CDATA #REQUIRED>
+<!ELEMENT resources (string)*>
 
-<!ELEMENT Section (String)*>
-<!ATTLIST Section
-          Name CDATA #REQUIRED>
-
-<!ELEMENT String EMPTY>
-<!ATTLIST String
-          Name CDATA #REQUIRED
-          Text CDATA #REQUIRED>
+<!ELEMENT string (#PCDATA)>
+<!ATTLIST string
+          name CDATA #REQUIRED>

--- a/MediaPortal/Resources/Schemas/Language.xsd
+++ b/MediaPortal/Resources/Schemas/Language.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 
 <!-- TODO: Changes in language descriptors:
   - DescriptorVersion="1.0" einfügen
@@ -6,39 +6,27 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <!-- Root element of a MediaPortal 2 language file. -->
-  <xs:element name="Language">
+  <xs:element name="resources">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="Section" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element ref="string" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
 
       <!-- Version of the descriptor file syntax. Must be "1.0". -->
-      <xs:attribute name="DescriptorVersion" type="xs:string" use="required" fixed="1.0"/>
-    </xs:complexType>
-  </xs:element>
-
-  <!-- Defines a string section. A section is a logical group of strings. -->
-  <xs:element name="Section">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="String" minOccurs="1" maxOccurs="unbounded"/>
-      </xs:sequence>
-
-      <!-- Defines the name of a string section. Strings in different files but
-           which are located in sections of the same name are merged internally.
-           The name must not contain a dot ("."). -->
-      <xs:attribute name="Name" type="xs:string" use="required"/>
+      <!-- <xs:attribute name="DescriptorVersion" type="xs:string" use="required" fixed="1.0"/> -->
     </xs:complexType>
   </xs:element>
 
   <!-- Definition of a localization string. -->
-  <xs:element name="String">
+  <xs:element name="string">
     <xs:complexType>
-      <!-- Name of the locatlization string. The string name may contain dots ("."). -->
-      <xs:attribute name="Name" type="xs:string" use="required"/>
-
       <!-- Localized text string. May contain placeholders of the form "{0}", "{1}" etc. -->
-      <xs:attribute name="Text" type="xs:string" use="required"/>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <!-- Name of the localization string. The string name may contain dots ("."). -->
+          <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:extension>
+      </xs:simpleContent>
     </xs:complexType>
   </xs:element>
 </xs:schema>


### PR DESCRIPTION
This fixes the schema definition as *.dtd and *.xsd for the language files, which has been changed last year to make it Transifex compatible.

**_Document Type Definition (DTD)**_
The current SkinEngine language file including the current *.dtd can be found here:
http://pastebin.com/raw.php?i=wRjaXkr3

The current SkinEngine language file including the fixed *.dtd can be found here:
http://pastebin.com/raw.php?i=fqrVRBWA

The XML-Syntax can be checked by either copying the content of the linke above into Notepad++ (with XML Tools plugin installed) or by pasting and checking them online
at http://www.w3schools.com/xml/xml_validator.asp (at the bottom, IE only)
or http://www.xmlvalidation.com/documentation.html

The first one does not validate, while the fixed one does.

**_XML Schema Definition (XSD)**_
Validation can be done by using Notepad++ with the Xml Tools plugins, easily.
