### PR TITLE
added SystemStateMenu plugin

### DIFF
--- a/MediaPortal/Incubator/SystemStateMenu/General/Consts.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/General/Consts.cs
@@ -1,0 +1,81 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
+
+namespace MediaPortal.Plugins.SystemStateMenu
+{
+  public class Consts
+  {
+    public const string STR_WF_STATE_ID_SYSTEM_STATE_DIALOG = "BBFA7DB7-5055-48D5-A904-0F0C79849369";
+    public const string STR_WF_STATE_ID_SYSTEM_STATE_CONFIGURATION_DIALOG = "F499DC76-2BCE-4126-AF4E-7FEB9DB88E80";
+
+    public static readonly Guid WF_STATE_ID_SYSTEM_STATE_DIALOG = new Guid(STR_WF_STATE_ID_SYSTEM_STATE_DIALOG);
+    public static readonly Guid WF_STATE_ID_SYSTEM_STATE_CONFIGURATION_DIALOG = new Guid(STR_WF_STATE_ID_SYSTEM_STATE_CONFIGURATION_DIALOG);
+
+    // Localization resource identifiers
+    public const string RES_SYSTEM_HIBERNATE_MENU_ITEM = "[SystemState.Hibernate]";
+    public const string RES_SYSTEM_SHUTDOWN_MENU_ITEM = "[SystemState.Shutdown]";
+    public const string RES_SYSTEM_SUSPEND_MENU_ITEM = "[SystemState.Suspend]";
+    public const string RES_SYSTEM_RESTART_MENU_ITEM = "[SystemState.Restart]";
+    public const string RES_SYSTEM_LOGOFF_MENU_ITEM = "[SystemState.Logoff]";
+
+    public const string RES_MEDIAPORTAL_MINIMIZE_MENU_ITEM = "[SystemState.MinimizeMP]";
+    public const string RES_MEDIAPORTAL_SHUTDOWN_MENU_ITEM = "[SystemState.ShutdownMP]";
+
+    // Accessor keys for GUI communication
+    public const string KEY_NAME = "Name";
+    public const string KEY_INDEX = "Sort-Index";
+
+    // ShutdownConfigurationDialogModel
+    public const string KEY_IS_CHECKED = "IsChecked";
+    public const string KEY_IS_DOWN_BUTTON_FOCUSED = "IsDownButtonFocused";
+    public const string KEY_IS_UP_BUTTON_FOCUSED = "IsUpButtonFocused";
+
+    public static string GetResourceIdentifierForMenuItem(SystemStateAction systemStateAction, bool timerActive = false)
+    {
+      switch (systemStateAction)
+      {
+        case SystemStateAction.Suspend:
+          return RES_SYSTEM_SUSPEND_MENU_ITEM;
+        case SystemStateAction.Hibernate:
+          return RES_SYSTEM_HIBERNATE_MENU_ITEM;
+        case SystemStateAction.Shutdown:
+          return RES_SYSTEM_SHUTDOWN_MENU_ITEM;
+        case SystemStateAction.Logoff:
+          return RES_SYSTEM_LOGOFF_MENU_ITEM;
+        case SystemStateAction.Restart:
+          return RES_SYSTEM_RESTART_MENU_ITEM;
+
+        case SystemStateAction.CloseMP:
+          return RES_MEDIAPORTAL_SHUTDOWN_MENU_ITEM;
+        case SystemStateAction.MinimizeMP:
+          return RES_MEDIAPORTAL_MINIMIZE_MENU_ITEM;
+
+        default:
+          return string.Empty;
+      }
+    }
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Helper Classes/SystemStateAction.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Helper Classes/SystemStateAction.cs
@@ -1,0 +1,37 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+namespace MediaPortal.Plugins.SystemStateMenu
+{
+  public enum SystemStateAction
+  {
+    Shutdown,
+    Suspend,
+    Hibernate,
+    Restart,
+    Logoff,
+    MinimizeMP,
+    CloseMP
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Helper Classes/SystemStateItem.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Helper Classes/SystemStateItem.cs
@@ -1,0 +1,48 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+namespace MediaPortal.Plugins.SystemStateMenu
+{
+  /// <summary>
+  /// This is a basic class where the information for the provider are stored (usually the location name and unique id).
+  /// </summary>
+  public class SystemStateItem
+  {
+    internal SystemStateItem(SystemStateAction action, bool enabled)
+    {
+      Action = action;
+      Enabled = enabled;
+    }
+
+    public SystemStateItem() { }
+
+    public SystemStateAction Action { get; set; }
+    public bool Enabled { get; set; }
+
+    public override string ToString()
+    {
+      return Action.ToString();
+    }
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Language/strings_en.xml
+++ b/MediaPortal/Incubator/SystemStateMenu/Language/strings_en.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="Settings.General.System.SystemStateDialog">Shutdown menu</string>
+  <string name="Settings.General.System.SystemStateDialog.Help">Configure visibility and position of shutdown menu items</string>
+
+  <string name="SystemState.Configuration.Dialog.Title">Configure shutdown items</string>
+
+  <string name="SystemState.Title">Shutdown menu</string>
+
+  <string name="SystemState.Hibernate">Hibernate</string>
+  <string name="SystemState.Shutdown">Shutdown</string>
+  <string name="SystemState.Suspend">Suspend</string>
+  <string name="SystemState.Restart">Restart</string>
+  <string name="SystemState.Logoff">Logoff</string>
+
+  <string name="SystemState.MinimizeMP">Minimize MediaPortal</string>
+  <string name="SystemState.ShutdownMP">Close MediaPortal</string>
+</resources>

--- a/MediaPortal/Incubator/SystemStateMenu/Models/SystemStateConfigurationModel.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Models/SystemStateConfigurationModel.cs
@@ -1,0 +1,263 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using MediaPortal.Common;
+using MediaPortal.Common.Settings;
+using MediaPortal.Plugins.SystemStateMenu.Settings;
+using MediaPortal.UI.Presentation.DataObjects;
+using MediaPortal.UI.Presentation.Models;
+using MediaPortal.UI.Presentation.Workflow;
+
+namespace MediaPortal.Plugins.SystemStateMenu.Models
+{
+  /// <summary>
+  /// Workflow model for the system state configuration.
+  /// </summary>
+  public class SystemStateConfigurationModel : IWorkflowModel
+  {
+    public const string SYSTEM_STATE_CONFIGURATION_MODEL_ID_STR = "869C15FC-AF55-4003-BF0D-F5AF7B6D0B3B";
+
+    #region Private fields
+
+    private List<SystemStateItem> _shutdownItemList;
+    private ItemsList _shutdownItems = null;
+
+    protected int _topIndex = 0;
+    protected int _focusedDownButton = -1;
+    protected int _focusedUpButton = -1;
+
+    #endregion
+
+    public SystemStateConfigurationModel()
+    {
+      _shutdownItemList = null;
+    }
+
+    #region Private methods
+
+    /// <summary>
+    /// Loads shutdown actions from the settings.
+    /// </summary>
+    private void GetShutdownActionsFromSettings()
+    {
+      SystemStateDialogSettings settings = ServiceRegistration.Get<ISettingsManager>().Load<SystemStateDialogSettings>();
+      _shutdownItemList = settings.ShutdownItemList;
+    }
+
+    private bool ItemCheckedChanged(int index, ListItem item)
+    {
+      bool isChecked = (bool) item.AdditionalProperties[Consts.KEY_IS_CHECKED];
+
+      _shutdownItemList[index].Enabled = isChecked;
+
+      return true;
+    }
+
+    private bool MoveItemUp(int index, ListItem item)
+    {
+      if (index <= 0 || index >= _shutdownItems.Count)
+        return false;
+      Utilities.CollectionUtils.Swap(_shutdownItemList, index, index - 1);
+
+      _focusedDownButton = -1;
+      _focusedUpButton = index - 1;
+
+      UpdateShutdownItems();
+      return true;
+    }
+
+    private bool MoveItemDown(int index, ListItem item)
+    {
+      if (index < 0 || index >= _shutdownItems.Count - 1)
+        return false;
+      Utilities.CollectionUtils.Swap(_shutdownItemList, index, index + 1);
+
+      _focusedDownButton = index + 1;
+      _focusedUpButton = -1;
+
+      UpdateShutdownItems();
+      return true;
+    }
+
+    private bool TryGetIndex(ListItem item, out int index)
+    {
+      index = -1;
+      if (item == null)
+        return false;
+      object oIndex;
+      if (item.AdditionalProperties.TryGetValue(Consts.KEY_INDEX, out oIndex))
+      {
+        int? i = oIndex as int?;
+        if (i.HasValue)
+        {
+          index = i.Value;
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private void UpdateShutdownItems()
+    {
+      _shutdownItems.Clear();
+      if (_shutdownItemList != null)
+      {
+        for (int i = 0; i < _shutdownItemList.Count; i++)
+        {
+          SystemStateItem si = _shutdownItemList[i];
+
+          ListItem item = new ListItem();
+          item.SetLabel(Consts.KEY_NAME, Consts.GetResourceIdentifierForMenuItem(si.Action));
+
+          item.AdditionalProperties[Consts.KEY_IS_CHECKED] = si.Enabled;
+          item.AdditionalProperties[Consts.KEY_IS_DOWN_BUTTON_FOCUSED] = i == _focusedDownButton;
+          item.AdditionalProperties[Consts.KEY_IS_UP_BUTTON_FOCUSED] = i == _focusedUpButton;
+          item.AdditionalProperties[Consts.KEY_INDEX] = i;
+          _shutdownItems.Add(item);
+        }
+        _focusedDownButton = -1;
+        _focusedUpButton = -1;
+      }
+      _shutdownItems.FireChange();
+    }
+
+    #endregion
+
+    #region Public properties (can be used by the GUI)
+
+    public ItemsList ShutdownItems
+    {
+      get { return _shutdownItems; }
+    }
+
+    #endregion
+
+    #region Public methods (can be used by the GUI)
+
+    /// <summary>
+    /// Saves the current state to the settings file.
+    /// </summary>
+    public void SaveSettings()
+    {
+      ISettingsManager settingsManager = ServiceRegistration.Get<ISettingsManager>();
+      SystemStateDialogSettings settings = settingsManager.Load<SystemStateDialogSettings>();
+      // Apply new shutdown item list
+      settings.ShutdownItemList = _shutdownItemList;
+
+      settingsManager.Save(settings);
+    }
+
+    /// <summary>
+    /// Provides a callable method for the skin to change the checked state of a given shutdown <paramref name="item"/> in the itemlist.
+    /// </summary>
+    /// <param name="item">The choosen item.</param>
+    public void CheckedChange(ListItem item)
+    {
+      int index;
+      if (TryGetIndex(item, out index))
+        ItemCheckedChanged(index, item);
+    }
+
+    /// <summary>
+    /// Provides a callable method for the skin to move the given shutdown <paramref name="item"/> up in the itemlist.
+    /// </summary>
+    /// <param name="item">The choosen item.</param>
+    public void MoveUp(ListItem item)
+    {
+      int index;
+      if (TryGetIndex(item, out index))
+        MoveItemUp(index, item);
+    }
+
+    /// <summary>
+    /// Provides a callable method for the skin to move the given shutdown <paramref name="item"/> down in the itemlist.
+    /// </summary>
+    /// <param name="item">The choosen item.</param>
+    public void MoveDown(ListItem item)
+    {
+      int index;
+
+      if (TryGetIndex(item, out index))
+        MoveItemDown(index, item);
+    }
+
+    #endregion
+
+    #region IWorkflowModel implementation
+
+    public Guid ModelId
+    {
+      get { return new Guid(SYSTEM_STATE_CONFIGURATION_MODEL_ID_STR); }
+    }
+
+    public bool CanEnterState(NavigationContext oldContext, NavigationContext newContext)
+    {
+      return true;
+    }
+
+    public void EnterModelContext(NavigationContext oldContext, NavigationContext newContext)
+    {
+      _shutdownItemList = new List<SystemStateItem>();
+      _shutdownItems = new ItemsList();
+      // Load settings
+      GetShutdownActionsFromSettings();
+      UpdateShutdownItems();
+    }
+
+    public void ExitModelContext(NavigationContext oldContext, NavigationContext newContext)
+    {
+      _shutdownItems.Clear();
+      _shutdownItems = null;
+    }
+
+    public void ChangeModelContext(NavigationContext oldContext, NavigationContext newContext, bool push)
+    {
+      // TODO
+    }
+
+    public void Deactivate(NavigationContext oldContext, NavigationContext newContext)
+    {
+      // Nothing to do here
+    }
+
+    public void Reactivate(NavigationContext oldContext, NavigationContext newContext)
+    {
+      // Nothing to do here
+    }
+
+    public void UpdateMenuActions(NavigationContext context, IDictionary<Guid, WorkflowAction> actions)
+    {
+      // Nothing to do here
+    }
+
+    public ScreenUpdateMode UpdateScreen(NavigationContext context, ref string screen)
+    {
+      return ScreenUpdateMode.AutoWorkflowManager;
+    }
+
+    #endregion
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Models/SystemStateModel.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Models/SystemStateModel.cs
@@ -1,0 +1,232 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using MediaPortal.Common;
+using MediaPortal.Common.Runtime;
+using MediaPortal.Common.Settings;
+using MediaPortal.Plugins.SystemStateMenu.Settings;
+using MediaPortal.UI.Presentation.DataObjects;
+using MediaPortal.UI.Presentation.Models;
+using MediaPortal.UI.Presentation.Screens;
+using MediaPortal.UI.Presentation.Workflow;
+
+namespace MediaPortal.Plugins.SystemStateMenu.Models
+{
+  /// <summary>
+  /// Workflow model for the SystemState dialog.
+  /// </summary>
+  public class SystemStateModel : IWorkflowModel
+  {
+    public const string SYSTEM_STATE_MODEL_ID_STR = "25F16911-ED0D-4439-9858-5E69C970C037";
+
+    #region Private fields
+
+    private ItemsList _shutdownItems = null;
+
+    public SystemStateModel()
+    {
+      ShutdownItemList = null;
+    }
+
+    #endregion
+
+    private List<SystemStateItem> ShutdownItemList { get; set; }
+
+    #region Private members
+
+    private void GetShutdownActionsFromSettings()
+    {
+      SystemStateDialogSettings settings = ServiceRegistration.Get<ISettingsManager>().Load<SystemStateDialogSettings>();
+      ShutdownItemList = settings.ShutdownItemList;
+    }
+
+    private bool TryGetAction(ListItem item, out SystemStateAction action)
+    {
+      action = SystemStateAction.Suspend;
+      if (item == null)
+        return false;
+
+      object oIndex;
+      if (item.AdditionalProperties.TryGetValue(Consts.KEY_INDEX, out oIndex))
+      {
+        int? i = oIndex as int?;
+        if (i.HasValue)
+        {
+          action = ShutdownItemList[i.Value].Action;
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private void UpdateShutdownItems()
+    {
+      _shutdownItems.Clear();
+      if (ShutdownItemList != null)
+      {
+        for (int i = 0; i < ShutdownItemList.Count; i++)
+        {
+          SystemStateItem si = ShutdownItemList[i];
+
+          // hide disabled items
+          if (!si.Enabled)
+            continue;
+
+          ListItem item = new ListItem();
+          item.SetLabel(Consts.KEY_NAME, Consts.GetResourceIdentifierForMenuItem(si.Action));
+
+          item.AdditionalProperties[Consts.KEY_INDEX] = i;
+          _shutdownItems.Add(item);
+        }
+      }
+      _shutdownItems.FireChange();
+    }
+
+    #endregion
+
+    #region Public properties (can be used by the GUI)
+
+    public ItemsList ShutdownItems
+    {
+      get { return _shutdownItems; }
+    }
+
+    #endregion
+
+    public static void DoAction(SystemStateAction action)
+    {
+      switch (action)
+      {
+        case SystemStateAction.Suspend:
+          ServiceRegistration.Get<ISystemStateService>().Suspend();
+          return;
+
+        case SystemStateAction.Hibernate:
+          ServiceRegistration.Get<ISystemStateService>().Hibernate();
+          return;
+
+        case SystemStateAction.Shutdown:
+          ServiceRegistration.Get<ISystemStateService>().Shutdown();
+          return;
+
+        case SystemStateAction.Restart:
+          ServiceRegistration.Get<ISystemStateService>().Restart();
+          return;
+
+        case SystemStateAction.Logoff:
+          ServiceRegistration.Get<ISystemStateService>().Logoff();
+          return;
+
+
+        case SystemStateAction.CloseMP:
+          ServiceRegistration.Get<IScreenControl>().Shutdown();
+          return;
+
+        case SystemStateAction.MinimizeMP:
+          ServiceRegistration.Get<IScreenControl>().Minimize();
+          return;
+      }
+    }
+
+    #region Public methods (can be used by the GUI)
+
+    /// <summary>
+    /// Provides a callable method for the skin to execute the given shutdown <paramref name="item"/>.
+    /// </summary>
+    /// <param name="item">The choosen item.</param>
+    public void Select(ListItem item)
+    {
+      if (item == null)
+        return;
+
+      SystemStateAction action;
+      if (!TryGetAction(item, out action))
+        return;
+
+      // todo: chefkoch, 2012-12-15: should this be done by the skin file?
+      ServiceRegistration.Get<IWorkflowManager>().NavigatePop(1);
+
+      DoAction(action);
+    }
+
+    #endregion
+
+    #region IWorkflowModel implementation
+
+    public Guid ModelId
+    {
+      get { return new Guid(SYSTEM_STATE_MODEL_ID_STR); }
+    }
+
+    public bool CanEnterState(NavigationContext oldContext, NavigationContext newContext)
+    {
+      return true;
+    }
+
+    public void EnterModelContext(NavigationContext oldContext, NavigationContext newContext)
+    {
+      ShutdownItemList = new List<SystemStateItem>();
+      _shutdownItems = new ItemsList();
+      //// Load settings
+      GetShutdownActionsFromSettings();
+      UpdateShutdownItems();
+    }
+
+    public void ExitModelContext(NavigationContext oldContext, NavigationContext newContext)
+    {
+      _shutdownItems.Clear();
+      _shutdownItems = null;
+      //_isTimerActiveProperty = null;
+    }
+
+    public void ChangeModelContext(NavigationContext oldContext, NavigationContext newContext, bool push)
+    {
+      // TODO
+    }
+
+    public void Deactivate(NavigationContext oldContext, NavigationContext newContext)
+    {
+      // Nothing to do here
+    }
+
+    public void Reactivate(NavigationContext oldContext, NavigationContext newContext)
+    {
+      // Nothing to do here
+    }
+
+    public void UpdateMenuActions(NavigationContext context, IDictionary<Guid, WorkflowAction> actions)
+    {
+      // Nothing to do here
+    }
+
+    public ScreenUpdateMode UpdateScreen(NavigationContext context, ref string screen)
+    {
+      return ScreenUpdateMode.AutoWorkflowManager;
+    }
+
+    #endregion
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Properties/AssemblyInfo.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden 
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die mit einer Assembly verknüpft sind.
+[assembly: AssemblyTitle("SystemStateMenu")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
+// für COM-Komponenten. Wenn Sie auf einen Typ in dieser Assembly von 
+// COM zugreifen müssen, legen Sie das ComVisible-Attribut für diesen Typ auf "true" fest.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("60db5b98-6a1d-4afc-a44e-41bff1dd4826")]
+
+// Other attributes are included from VersionInfo.cs!

--- a/MediaPortal/Incubator/SystemStateMenu/Settings/Configuration/General/SystemStateDialogSettings.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Settings/Configuration/General/SystemStateDialogSettings.cs
@@ -1,0 +1,32 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using MediaPortal.Common.Configuration.ConfigurationClasses;
+
+namespace MediaPortal.Plugins.SystemStateMenu.Settings.Configuration.General
+{
+  public class SystemStateDialogSettings : CustomConfigSetting
+  {
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Settings/SystemStateSettings.cs
+++ b/MediaPortal/Incubator/SystemStateMenu/Settings/SystemStateSettings.cs
@@ -1,0 +1,81 @@
+#region Copyright (C) 2007-2013 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2013 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System.Collections.Generic;
+using MediaPortal.Common.Settings;
+
+namespace MediaPortal.Plugins.SystemStateMenu.Settings
+{
+  /// <summary>
+  /// Shutdown settings class.
+  /// </summary>
+  public class SystemStateDialogSettings
+  {
+    private List<SystemStateItem> _shutdownItemList;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public SystemStateDialogSettings()
+    {
+      ShutdownItemList = new List<SystemStateItem>();
+    }
+
+    [Setting(SettingScope.User, 60)]
+    public int? LastCustomSleepTimeout { get; set; }
+
+    [Setting(SettingScope.User, SystemStateAction.Suspend)]
+    public SystemStateAction? LastCustomSleepAction { get; set; }
+
+    [Setting(SettingScope.User, null)]
+    public List<SystemStateItem> ShutdownItemList
+    {
+      get
+      {
+        if (_shutdownItemList == null)
+          CreateDefaultShutdownMenu();
+
+        return _shutdownItemList;
+      }
+      set
+      {
+        _shutdownItemList = value;
+      }
+    }
+
+    private void CreateDefaultShutdownMenu()
+    {
+      _shutdownItemList = new List<SystemStateItem>
+                            {
+                              new SystemStateItem(SystemStateAction.Suspend, true),
+                              new SystemStateItem(SystemStateAction.Hibernate, true),
+                              new SystemStateItem(SystemStateAction.Shutdown, true),
+                              new SystemStateItem(SystemStateAction.Restart, true),
+                              new SystemStateItem(SystemStateAction.CloseMP, true),
+                              new SystemStateItem(SystemStateAction.MinimizeMP, false),
+                              new SystemStateItem(SystemStateAction.Logoff, false)
+                            };
+    }
+  }
+}

--- a/MediaPortal/Incubator/SystemStateMenu/Skin/default/screens/dialogSystemState.xaml
+++ b/MediaPortal/Incubator/SystemStateMenu/Skin/default/screens/dialogSystemState.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include
+    xmlns="www.team-mediaportal.com/2008/mpf/directx"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Source="screens\master_dialog_bare.xaml"
+    >
+
+  <Include.Resources>
+
+    <!-- Header -->
+    <ResourceWrapper x:Key="Dialog_Header_Text" Resource="[SystemState.Title]"/>
+
+    <!-- SystemStateModel -->
+    <Model x:Key="SystemStateModel"
+           Id="25F16911-ED0D-4439-9858-5E69C970C037"/>
+
+    <!-- Contents -->
+    <ControlTemplate x:Key="Contents_Template">
+      <StackPanel DataContext="{Binding Source={StaticResource SystemStateModel}}">
+
+        <ListView Grid.Column="0"
+                  Grid.Row="0"
+                  SetFocusPrio="Default"
+                  Style="{ThemeResource MenuListViewStyle}"
+                  ItemsSource="{Binding ShutdownItems}">
+          <ListView.Resources>
+            <Command x:Key="Menu_Command"
+                     Source="{StaticResource SystemStateModel}"
+                     Path="Select"
+                     Parameters="{LateBoundValue BindingValue={Binding}}" />
+          </ListView.Resources>
+        </ListView>
+      </StackPanel>
+    </ControlTemplate>
+
+  </Include.Resources>
+</Include>

--- a/MediaPortal/Incubator/SystemStateMenu/Skin/default/screens/dialogSystemStateConfiguration.xaml
+++ b/MediaPortal/Incubator/SystemStateMenu/Skin/default/screens/dialogSystemStateConfiguration.xaml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include
+    xmlns="www.team-mediaportal.com/2008/mpf/directx"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Source="screens\master_dialog_bare.xaml"
+    >
+
+  <Include.Resources>
+
+    <!-- Header -->
+    <ResourceWrapper x:Key="Dialog_Header_Text" Resource="[SystemState.Configuration.Dialog.Title]"/>
+
+    <!-- SystemStateConfigurationModel -->
+    <Model x:Key="SystemStateConfigurationModel"
+           Id="869C15FC-AF55-4003-BF0D-F5AF7B6D0B3B" />
+
+    <!-- Contents -->
+    <ControlTemplate x:Key="Contents_Template">
+      <StackPanel DataContext="{Binding Source={StaticResource SystemStateConfigurationModel}}">
+        
+        <ListView Grid.Column="0"
+                  Grid.Row="0"
+                  Style="{ThemeResource SystemStateConfigurationListViewStyle}"
+                  ItemsSource="{Binding ShutdownItems}">
+          <ListView.Resources>
+            <Command x:Key="CheckedChange_Command"
+                     Source="{StaticResource SystemStateConfigurationModel}"
+                     Path="CheckedChange"
+                     Parameters="{LateBoundValue BindingValue={Binding}}" />
+            <Command x:Key="MoveUp_Command"
+                     Source="{StaticResource SystemStateConfigurationModel}"
+                     Path="MoveUp"
+                     Parameters="{LateBoundValue BindingValue={Binding}}" />
+            <Command x:Key="MoveDown_Command"
+                     Source="{StaticResource SystemStateConfigurationModel}"
+                     Path="MoveDown"
+                     Parameters="{LateBoundValue BindingValue={Binding}}" />
+          </ListView.Resources>
+        </ListView>
+
+        <!-- OK & Abort button -->
+        <Grid HorizontalAlignment="Stretch">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+          </Grid.RowDefinitions>
+
+          <Button Name="ButtonOk"
+                  Grid.Column="0"
+                  Grid.Row="0"
+                  Style="{ThemeResource DialogButtonStyle}"
+                  Content="[System.Ok]"
+                  HorizontalAlignment="Center">
+            <Button.Command>
+              <CommandList>
+                <Command Path="SaveSettings" />
+                <Command Source="{Service ScreenManager}"
+                         Path="CloseTopmostDialog" />
+              </CommandList>
+            </Button.Command>
+          </Button>
+
+          <Button Name="ButtonCancel"
+                  Grid.Column="1"
+                  Grid.Row="0"
+                  SetFocusPrio="Default"
+                  Style="{ThemeResource DialogButtonStyle}"
+                  Content="[System.Cancel]"
+                  HorizontalAlignment="Center"
+                  Command="{Command Source={Service ScreenManager},Path=CloseTopmostDialog}" />
+        </Grid>
+      </StackPanel>
+    </ControlTemplate>
+
+  </Include.Resources>
+</Include>

--- a/MediaPortal/Incubator/SystemStateMenu/Skin/default/shortcuts/systemstate-shortcuts.xml
+++ b/MediaPortal/Incubator/SystemStateMenu/Skin/default/shortcuts/systemstate-shortcuts.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Shortcut DescriptorVersion="1.0">
+  <WorkflowStates>
+    <!-- Name="dialogSystemState" -->
+    <Shortcut Key="S:Power" WorkflowState="BBFA7DB7-5055-48D5-A904-0F0C79849369" />
+  </WorkflowStates>
+</Shortcut>

--- a/MediaPortal/Incubator/SystemStateMenu/Skin/default/themes/default/styles/SystemStateStyles.xaml
+++ b/MediaPortal/Incubator/SystemStateMenu/Skin/default/themes/default/styles/SystemStateStyles.xaml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="www.team-mediaportal.com/2008/mpf/directx"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System"
+                    xmlns:collections="clr-namespace:MediaPortal.UI.Presentation.DataObjects;assembly=MediaPortal.UI"
+                    DependsOnStyleResources="Colors,Buttons">
+
+  <Style x:Key="SystemStateConfigurationItemContainerStyle"
+           BasedOn="{ThemeResource DefaultItemContainerStyle}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ListViewItem}">
+          <Grid x:Name="ParentPanel">
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <CheckBox x:Name="SystemStateActionMarker"
+                      Grid.Column="0"
+                      Grid.Row="0"
+                      Margin="2,1,0,1"
+                      Command="{DynamicResource ResourceKey=CheckedChange_Command}"
+                      IsChecked="{Binding Path=AdditionalProperties[IsChecked],Mode=TwoWay}" />
+
+            <Button x:Name="MoveUpButton"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="3"
+                    Width="30"
+                    Height="30"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Style="{ThemeResource ArrowButtonUpStyle}"
+                    Context="{Binding}"
+                    Command="{DynamicResource ResourceKey=MoveUp_Command}"
+                    SetFocus="{Binding Path=AdditionalProperties[IsUpButtonFocused],Mode=OneTime}" />
+
+            <Button x:Name="MoveDownButton"
+                    Grid.Column="2"
+                    Grid.Row="0"
+                    Margin="3"
+                    Width="30"
+                    Height="30"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Style="{ThemeResource ArrowButtonDownStyle}"
+                    Context="{Binding}"
+                    Command="{DynamicResource ResourceKey=MoveDown_Command}"
+                    SetFocus="{Binding Path=AdditionalProperties[IsDownButtonFocused],Mode=OneTime}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <!-- ListView style to be used for all menus (main menu, dialog menus, context menus, ...) -->
+  <Style x:Key="SystemStateConfigurationListViewStyle"
+           BasedOn="{ThemeResource DefaultListViewStyle}">
+    <!--
+    <Setter Property="ItemTemplate"
+            Value="{ThemeResource DefaultItemDataTemplate}" />
+    <Setter Property="DataStringProvider"
+            Value="{ThemeResource DefaultItemDataStringProvider}" />
+    -->
+    <Setter Property="ItemContainerStyle"
+            Value="{ThemeResource SystemStateConfigurationItemContainerStyle}" />
+  </Style>
+
+</ResourceDictionary>

--- a/MediaPortal/Incubator/SystemStateMenu/Skin/default/workflow/systemstate-actions.xml
+++ b/MediaPortal/Incubator/SystemStateMenu/Skin/default/workflow/systemstate-actions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Workflow DescriptorVersion="1.0">
+  <MenuActions>
+    <PushNavigationTransition Id="72480EE1-64D7-4BD5-943C-22C6DE2D4A9D"
+        Name="Home->SystemStateDialog"
+        DisplayCategory="b-SystemState"
+        SortOrder="a"
+        SourceStates="7F702D9C-F2DD-42da-9ED8-0BA92F07787F"
+        TargetState="BBFA7DB7-5055-48D5-A904-0F0C79849369"
+        DisplayTitle="[SystemState.Title]"/>
+  </MenuActions>
+</Workflow>

--- a/MediaPortal/Incubator/SystemStateMenu/SystemStateMenu.csproj
+++ b/MediaPortal/Incubator/SystemStateMenu/SystemStateMenu.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8E94A59D-33A0-4AEB-830D-24304A63EF23}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MediaPortal.Plugins.SystemStateMenu</RootNamespace>
+    <AssemblyName>SystemStateMenu</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <CodeAnalysisLogFile>bin\Debug\ClassLibrary1.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
+    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
+    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
+    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
+    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <CodeAnalysisLogFile>bin\Release\ClassLibrary1.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
+    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
+    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
+    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
+    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Source\Core\MediaPortal.Common\VersionInfo\VersionInfo.cs">
+      <Link>Properties\VersionInfo.cs</Link>
+    </Compile>
+    <Compile Include="General\Consts.cs" />
+    <Compile Include="Helper Classes\SystemStateItem.cs" />
+    <Compile Include="Helper Classes\SystemStateAction.cs" />
+    <Compile Include="Models\SystemStateConfigurationModel.cs" />
+    <Compile Include="Models\SystemStateModel.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Settings\Configuration\General\SystemStateDialogSettings.cs" />
+    <Compile Include="Settings\SystemStateSettings.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Language\strings_en.xml" />
+    <Content Include="plugin.xml" />
+    <Content Include="Skin\default\screens\dialogSystemState.xaml">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Skin\default\screens\dialogSystemStateConfiguration.xaml">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Skin\default\shortcuts\systemstate-shortcuts.xml" />
+    <Content Include="Skin\default\themes\default\styles\SystemStateStyles.xaml">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Skin\default\workflow\systemstate-actions.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\Core\MediaPortal.Common\MediaPortal.Common.csproj">
+      <Project>{ECF060E7-CAA1-4466-851F-F80B857641EA}</Project>
+      <Name>MediaPortal.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Source\Core\MediaPortal.UI\MediaPortal.UI.csproj">
+      <Project>{52E587D0-A274-44DA-8846-8EEAF5414923}</Project>
+      <Name>MediaPortal.UI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Source\Core\MediaPortal.Utilities\MediaPortal.Utilities.csproj">
+      <Project>{4FE7B8AE-1330-424A-91A1-C68D7ABF9CB8}</Project>
+      <Name>MediaPortal.Utilities</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Source\UI\UiComponents\SkinBase\SkinBase.csproj">
+      <Project>{4EFED5BE-2F6A-4944-BB96-053D5945BA1F}</Project>
+      <Name>SkinBase</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y "$(ProjectDir)plugin.xml" "$(SolutionDir)..\Bin\$(SolutionName)\$(OutDir)Plugins\$(ProjectName)\"
+mkdir "$(SolutionDir)..\Bin\$(SolutionName)\$(OutDir)Plugins\$(ProjectName)\Language"
+robocopy "$(ProjectDir)Language" "$(SolutionDir)..\Bin\$(SolutionName)\$(OutDir)Plugins\$(ProjectName)\Language" /MIR /NP
+mkdir "$(SolutionDir)..\Bin\$(SolutionName)\$(OutDir)Plugins\$(ProjectName)\Skin"
+robocopy "$(ProjectDir)Skin" "$(SolutionDir)..\Bin\$(SolutionName)\$(OutDir)Plugins\$(ProjectName)\Skin" /MIR /NP
+xcopy /Y "$(TargetDir)$(ProjectName).dll"  "$(SolutionDir)..\Bin\$(SolutionName)\$(OutDir)Plugins\$(ProjectName)\"
+</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MediaPortal/Incubator/SystemStateMenu/plugin.xml
+++ b/MediaPortal/Incubator/SystemStateMenu/plugin.xml
@@ -1,0 +1,63 @@
+<Plugin
+    DescriptorVersion="1.0"
+    Name="SystemStateMenu"
+    PluginId="{E5326D7C-698F-48C2-AA15-AD6CCBD1A96F}"
+    Author="chefkoch"
+    Copyright="GPL"
+    Description="The SystemStateMenu plugin provides a menu to shutdown, suspend or restart the PC."
+    PluginVersion="1.0">
+
+  <DependsOn>
+    <!-- SkinEngine -->
+    <PluginReference PluginId="{D87D92F0-5E71-470a-A2A4-430F90A28BF3}"/>
+    <!-- ConfigurationManager -->
+    <PluginReference PluginId="{1AFF4467-64B0-4ca1-AF28-9AEDF3525BCE}"/>
+  </DependsOn>
+
+  <Runtime>
+    <Assembly FileName="SystemStateMenu.dll"/>
+  </Runtime>
+
+  <Register Location="/Models">
+    <Model Id="25F16911-ED0D-4439-9858-5E69C970C037"
+           Name="SystemStateModel"
+           ClassName="MediaPortal.Plugins.SystemStateMenu.Models.SystemStateModel"/>
+    <Model Id="869C15FC-AF55-4003-BF0D-F5AF7B6D0B3B"
+           Name="SystemStateConfigurationModel"
+           ClassName="MediaPortal.Plugins.SystemStateMenu.Models.SystemStateConfigurationModel"/>
+  </Register>
+
+  <Register Location="/Workflow/States">
+    <!-- SystemState Dialog -->
+    <DialogState Id="BBFA7DB7-5055-48D5-A904-0F0C79849369"
+                 Name="dialogSystemState"
+                 DialogScreen="dialogSystemState"
+                 DisplayLabel="[ShutdownManager.ShutdownDialogStateDisplayLabel]"
+                 WorkflowModel="25F16911-ED0D-4439-9858-5E69C970C037"/>
+    <!-- SystemStateConfiguration Dialog -->
+    <DialogState Id="F499DC76-2BCE-4126-AF4E-7FEB9DB88E80"
+                 Name="dialogSystemStateConfiguration"
+                 DialogScreen="dialogSystemStateConfiguration"
+                 DisplayLabel="[ShutdownManager.ShutdownConfigurationDialogStateDisplayLabel]"
+                 WorkflowModel="869C15FC-AF55-4003-BF0D-F5AF7B6D0B3B"/>
+  </Register>
+
+  <Register Location="/Resources/Language">
+    <Resource Id="SystemStateMenuLanguage" Directory="Language" Type="Language"/>
+  </Register>
+
+  <Register Location="/Resources/Skin">
+    <Resource Id="SystemStateMenuSkin" Directory="Skin" Type="Skin"/>
+  </Register>
+
+  <!-- Register SystemStateConfiguration at '/General/System' group -->
+  <Register Location="/Configuration/Settings/General/System">
+    <CustomConfigSetting
+        Id="SystemStateDialog"
+        Text="[Settings.General.System.SystemStateDialog]"
+        HelpText="[Settings.General.System.SystemStateDialog.Help]"
+        ClassName="MediaPortal.Plugins.SystemStateMenu.Settings.Configuration.General.SystemStateDialogSettings"
+        AdditionalData="WorkflowState=F499DC76-2BCE-4126-AF4E-7FEB9DB88E80,ConfAppPanel=..."/>
+  </Register>
+
+</Plugin>

--- a/MediaPortal/Source/MP2-Client.sln
+++ b/MediaPortal/Source/MP2-Client.sln
@@ -134,10 +134,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimTv.NativeProvider", "..
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StatisticsRenderer", "..\Incubator\StatisticsRenderer\StatisticsRenderer.csproj", "{C44C886F-27D3-4F6B-A894-42F5E2175591}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemStateMenu", "..\Incubator\SystemStateMenu\SystemStateMenu.csproj", "{8E94A59D-33A0-4AEB-830D-24304A63EF23}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MovieThumbnailer", "Extensions\MetadataExtractors\MovieThumbnailer\MovieThumbnailer.csproj", "{29935593-E22E-44A9-A9A2-683D5C0F3E57}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Titanium", "..\Incubator\Titanium\Titanium.csproj", "{5B09CF07-6386-44C1-B786-CAAC78835CAA}"
 EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -348,6 +351,10 @@ Global
 		{E17ACAD5-69AA-4205-BEBD-5E66A0183FDC}.Debug|x86.ActiveCfg = Debug|x86
 		{E17ACAD5-69AA-4205-BEBD-5E66A0183FDC}.Release|x86.ActiveCfg = Release|x86
 		{E17ACAD5-69AA-4205-BEBD-5E66A0183FDC}.Release|x86.Build.0 = Release|x86
+		{8E94A59D-33A0-4AEB-830D-24304A63EF23}.Debug|x86.ActiveCfg = Debug|x86
+		{8E94A59D-33A0-4AEB-830D-24304A63EF23}.Debug|x86.Build.0 = Debug|x86
+		{8E94A59D-33A0-4AEB-830D-24304A63EF23}.Release|x86.ActiveCfg = Release|x86
+		{8E94A59D-33A0-4AEB-830D-24304A63EF23}.Release|x86.Build.0 = Release|x86
 		{C44C886F-27D3-4F6B-A894-42F5E2175591}.Debug|x86.ActiveCfg = Debug|x86
 		{C44C886F-27D3-4F6B-A894-42F5E2175591}.Debug|x86.Build.0 = Debug|x86
 		{C44C886F-27D3-4F6B-A894-42F5E2175591}.Release|x86.ActiveCfg = Release|x86
@@ -425,5 +432,6 @@ Global
 		{F5A200C6-3E9C-4367-9950-E4F5A04FC0A5} = {91CC1D84-4327-48CA-8186-D7C3529AEB44}
 		{0CCF3B1A-64B1-4824-B01A-25CEFE9F5DAB} = {91CC1D84-4327-48CA-8186-D7C3529AEB44}
 		{F97C27E2-66FA-43B7-B11B-8A20ABE9D332} = {91CC1D84-4327-48CA-8186-D7C3529AEB44}
+		{8E94A59D-33A0-4AEB-830D-24304A63EF23} = {91CC1D84-4327-48CA-8186-D7C3529AEB44}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This includes a plugin providing a menu to shutdown, restart or suspend the system (change of SystemState).

**Features**
In detail the following menu entries are implemented:
- Shutdown system
- Suspend system (Standby)
- Hibernate system
- Restart system
- Close MediaPortal
- Minimize MediaPortal
  The position and the visibility can be configured within settings.

Additional entries, which could be added in future might be:
- Define custom shutdown timer... (--> SleepTimer feature)
- Restart MediaPortal
- Restart Server
- ...
  These are not part of this plugin/pull request.

**ToDo list for myself**
- [x] Initial commit of the plugin
- [x] [Remove Dialog from Menu](https://github.com/MediaPortal/MediaPortal-2/blob/c8e37aac7221ef1a4a80e55b28d662af73715871/MediaPortal/Incubator/SystemStateMenu/Skin/default/workflow/systemstate-actions.xml) after a new button has been to existing plugins
- [x] Add plugin to Transifex config plugin

**ToDo list for reviewer**
These things I am especially asking for review:
- [x] Review plugin name & location, names of classes, workflows, models, ...
- [x] Review localization: using [System.Shutdown] etc instead of creating new ones?
- [x] [Enum usage for MenuItems](https://github.com/MediaPortal/MediaPortal-2/blob/c8e37aac7221ef1a4a80e55b28d662af73715871/MediaPortal/Incubator/SystemStateMenu/Helper%20Classes/SystemStateAction.cs#L27-L36): Does the enum allows additional entries (like RestartMP, SleepTimer, ...) in future?

**unassigned tasks**
- [x] change skins to make use of the new menu, i.e. PowerButton if Mouse is active

**In-GUI screenshots of the plugin**
![Menu](https://f.cloud.github.com/assets/601866/240635/d56c2436-8937-11e2-9f60-ab26d012ae5d.png)
![ConfigSection](https://f.cloud.github.com/assets/601866/240637/ef9a5990-8937-11e2-87e3-4a470298107e.png)
![ConfigDialog](https://f.cloud.github.com/assets/601866/240639/f1d9a0a8-8937-11e2-880e-a11e2bb91436.png)
