### PR TITLE
Music: Filter by album artist

### DIFF
--- a/MediaPortal/Source/UI/UiComponents/Media/General/Consts.cs
+++ b/MediaPortal/Source/UI/UiComponents/Media/General/Consts.cs
@@ -340,7 +340,7 @@ namespace MediaPortal.UiComponents.Media.General
     public const string SCREEN_LOCAL_MEDIA_NAVIGATION = "LocalMediaNavigation";
     public const string SCREEN_AUDIO_SHOW_ITEMS = "AudioShowItems";
     public const string SCREEN_AUDIO_FILTER_BY_ARTIST = "AudioFilterByArtist";
-    public const string SCREEN_AUDIO_FILTER_BY_ALBUM_ARTIST = "AudioFilterByArtist";
+    public const string SCREEN_AUDIO_FILTER_BY_ALBUM_ARTIST = "AudioFilterByAlbumArtist";
     public const string SCREEN_AUDIO_FILTER_BY_ALBUM = "AudioFilterByAlbum";
     public const string SCREEN_AUDIO_FILTER_BY_GENRE = "AudioFilterByGenre";
     public const string SCREEN_AUDIO_FILTER_BY_DECADE = "AudioFilterByDecade";

--- a/MediaPortal/Source/UI/UiComponents/Media/General/Consts.cs
+++ b/MediaPortal/Source/UI/UiComponents/Media/General/Consts.cs
@@ -149,6 +149,7 @@ namespace MediaPortal.UiComponents.Media.General
     public const string RES_SIMPLE_SEARCH_VIEW_NAME = "[Media.SimpleSearchViewName]";
 
     public const string RES_FILTER_BY_ARTIST_MENU_ITEM = "[Media.FilterByArtistMenuItem]";
+    public const string RES_FILTER_BY_ALBUM_ARTIST_MENU_ITEM = "[Media.FilterByAlbumArtistMenuItem]";
     public const string RES_FILTER_BY_ALBUM_MENU_ITEM = "[Media.FilterByAlbumMenuItem]";
     public const string RES_FILTER_BY_AUDIO_GENRE_MENU_ITEM = "[Media.FilterByAudioGenreMenuItem]";
     public const string RES_FILTER_BY_DECADE_MENU_ITEM = "[Media.FilterByDecadeMenuItem]";
@@ -180,6 +181,7 @@ namespace MediaPortal.UiComponents.Media.General
     public const string RES_BROWSE_MEDIA_NAVIGATION_NAVBAR_DISPLAY_LABEL = "[Media.BrowseMediaNavigationNavbarDisplayLabel]";
     public const string RES_LOCAL_MEDIA_NAVIGATION_NAVBAR_DISPLAY_LABEL = "[Media.LocalMediaNavigationNavbarDisplayLabel]";
     public const string RES_FILTER_ARTIST_NAVBAR_DISPLAY_LABEL = "[Media.FilterArtistNavbarDisplayLabel]";
+    public const string RES_FILTER_ALBUM_ARTIST_NAVBAR_DISPLAY_LABEL = "[Media.FilterAlbumArtistNavbarDisplayLabel]";
     public const string RES_FILTER_ALBUM_NAVBAR_DISPLAY_LABEL = "[Media.FilterAlbumNavbarDisplayLabel]";
     public const string RES_FILTER_AUDIO_GENRE_NAVBAR_DISPLAY_LABEL = "[Media.FilterAudioGenreNavbarDisplayLabel]";
     public const string RES_FILTER_DECADE_NAVBAR_DISPLAY_LABEL = "[Media.FilterDecadeNavbarDisplayLabel]";
@@ -338,6 +340,7 @@ namespace MediaPortal.UiComponents.Media.General
     public const string SCREEN_LOCAL_MEDIA_NAVIGATION = "LocalMediaNavigation";
     public const string SCREEN_AUDIO_SHOW_ITEMS = "AudioShowItems";
     public const string SCREEN_AUDIO_FILTER_BY_ARTIST = "AudioFilterByArtist";
+    public const string SCREEN_AUDIO_FILTER_BY_ALBUM_ARTIST = "AudioFilterByArtist";
     public const string SCREEN_AUDIO_FILTER_BY_ALBUM = "AudioFilterByAlbum";
     public const string SCREEN_AUDIO_FILTER_BY_GENRE = "AudioFilterByGenre";
     public const string SCREEN_AUDIO_FILTER_BY_DECADE = "AudioFilterByDecade";

--- a/MediaPortal/Source/UI/UiComponents/Media/Language/strings_en.xml
+++ b/MediaPortal/Source/UI/UiComponents/Media/Language/strings_en.xml
@@ -18,6 +18,7 @@
 
   <!-- Filter titles -->
   <string name="Media.FilterByArtistMenuItem">Filter by artist</string>
+  <string name="Media.FilterByAlbumArtistMenuItem">Filter by album artist</string>
   <string name="Media.FilterByAlbumMenuItem">Filter by album</string>
   <string name="Media.FilterByAudioGenreMenuItem">Filter by genre</string>
   <string name="Media.FilterByDecadeMenuItem">Filter by decade</string>
@@ -59,6 +60,7 @@
   <string name="Media.BrowseMediaNavigationNavbarDisplayLabel">{0}</string> <!-- For example: "R.E.M." -->
   <string name="Media.LocalMediaNavigationNavbarDisplayLabel">{0}</string> <!-- For example: "R.E.M." -->
   <string name="Media.FilterArtistNavbarDisplayLabel">Artist: {0}</string> <!-- For example: "Artist: R.E.M." -->
+  <string name="Media.FilterAlbumArtistNavbarDisplayLabel">Album Artist: {0}</string>
   <string name="Media.FilterAlbumNavbarDisplayLabel">Album: {0}</string>
   <string name="Media.FilterAudioGenreNavbarDisplayLabel">Genre: {0}</string>
   <string name="Media.FilterDecadeNavbarDisplayLabel">Decade: {0}</string>

--- a/MediaPortal/Source/UI/UiComponents/Media/Language/strings_en.xml
+++ b/MediaPortal/Source/UI/UiComponents/Media/Language/strings_en.xml
@@ -132,6 +132,7 @@
   <string name="Media.ChooseAudioDecadeHeader">Choose a decade</string>
   <string name="Media.ChooseAlbumHeader">Choose an album</string>
   <string name="Media.ChooseArtistHeader">Choose an artist</string>
+  <string name="Media.ChooseAlbumArtistHeader">Choose an album artist</string>
   <string name="Media.ChooseAudioGenreHeader">Choose a genre</string>
   <string name="Media.ChooseImageYearHeader">Choose a year</string>
   <string name="Media.ChooseImageSizeHeader">Choose a size</string>

--- a/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Models\MediaItemsActionModel.cs" />
     <Compile Include="Models\ScreenData\AbstractBrowseMediaNavigationScreenData.cs" />
     <Compile Include="Models\ScreenData\AbstractMovieFilterScreenData.cs" />
+    <Compile Include="Models\ScreenData\AudioFilterByAlbumArtistScreenData.cs" />
     <Compile Include="Models\ScreenData\ImagesFilterByCityScreenData.cs" />
     <Compile Include="Models\ScreenData\ImagesFilterByStateScreenData.cs" />
     <Compile Include="Models\ScreenData\ImagesFilterByCountryScreenData.cs" />

--- a/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
@@ -401,6 +401,11 @@
       <SubType>Designer</SubType>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Skin\default\screens\AudioFilterByAlbumArtist.xaml">
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="build.targets" />
 </Project>

--- a/MediaPortal/Source/UI/UiComponents/Media/Models/NavigationModel/AudioNavigationInitializer.cs
+++ b/MediaPortal/Source/UI/UiComponents/Media/Models/NavigationModel/AudioNavigationInitializer.cs
@@ -52,6 +52,7 @@ namespace MediaPortal.UiComponents.Media.Models.NavigationModel
           new AudioShowItemsScreenData(_genericPlayableItemCreatorDelegate),
           // C# doesn't like it to have an assignment inside a collection initializer
           _defaultScreen,
+          new AudioFilterByAlbumArtistScreenData(),
           new AudioFilterByAlbumScreenData(),
           new AudioFilterByGenreScreenData(),
           new AudioFilterByDecadeScreenData(),

--- a/MediaPortal/Source/UI/UiComponents/Media/Models/ScreenData/AudioFilterByAlbumArtistScreenData.cs
+++ b/MediaPortal/Source/UI/UiComponents/Media/Models/ScreenData/AudioFilterByAlbumArtistScreenData.cs
@@ -1,0 +1,45 @@
+#region Copyright (C) 2007-2015 Team MediaPortal
+
+/*
+    Copyright (C) 2007-2015 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using MediaPortal.Common.MediaManagement.DefaultItemAspects;
+using MediaPortal.UiComponents.Media.FilterCriteria;
+using MediaPortal.UiComponents.Media.General;
+using MediaPortal.UiComponents.Media.Models.Navigation;
+
+namespace MediaPortal.UiComponents.Media.Models.ScreenData
+{
+  public class AudioFilterByAlbumArtistScreenData : AbstractAudioFilterScreenData
+  {
+    public AudioFilterByAlbumArtistScreenData() :
+      base(Consts.SCREEN_AUDIO_FILTER_BY_ALBUM_ARTIST, Consts.RES_FILTER_BY_ALBUM_ARTIST_MENU_ITEM,
+      Consts.RES_FILTER_ALBUM_ARTIST_NAVBAR_DISPLAY_LABEL, new SimpleMLFilterCriterion(AudioAspect.ATTR_ALBUMARTISTS))
+    {
+    }
+
+    public override AbstractFiltersScreenData<FilterItem> Derive()
+    {
+      return new AudioFilterByAlbumArtistScreenData();
+    }
+  }
+}

--- a/MediaPortal/Source/UI/UiComponents/Media/Skin/default/screens/AudioFilterByAlbumArtist.xaml
+++ b/MediaPortal/Source/UI/UiComponents/Media/Skin/default/screens/AudioFilterByAlbumArtist.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- TODO: This screen should be adapted to match its special filter function, i.e. add images etc. -->
+<Include
+    xmlns="www.team-mediaportal.com/2008/mpf/directx"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Source="screens\SimpleFilterItems.xaml"
+    >
+  <Include.Resources>
+
+    <!-- Header -->
+    <ResourceWrapper x:Key="Header_Text" Resource="[Media.ChooseAlbumArtistHeader]"/>
+
+  </Include.Resources>
+</Include>


### PR DESCRIPTION
# What this contribution contains
Option to filter audio by album artist tag.

# Motivation
Many artists release their albums with tags in following fashion:
- **Song 1:**
  - **Artist**: Main artist, feat. artist A
  - **Album**: Album A
  - **AlbumArtist**: Main artist

- **Song 2:**
  - **Artist**: Main artist, feat. artist B
  - **Album**: Album A
  - **AlbumArtist**: Main artist

When user wants to play all songs from artist *Main artist*, it is currently impossible to do so. If user filters songs by artist, all songs are in different grouping, e.g. *Main artist, feat. artist A* and *Main artist, feat. artist B*. With this patch, user can filter songs by the *Album Artist* tag and play the albums without too much additional effort.
