### PR TITLE
Fix bug MP2-786 Cannot play playlist with >=1000 entries

### DIFF
--- a/MediaPortal/Source/UI/UiComponents/Media/Models/ManagePlaylistsModel.cs
+++ b/MediaPortal/Source/UI/UiComponents/Media/Models/ManagePlaylistsModel.cs
@@ -326,7 +326,7 @@ namespace MediaPortal.UiComponents.Media.Models
       // 1) Load media item ids in the playlist
       // 2) Load media items in clusters - for each cluster, an own query will be executed at the content directory
       PlaylistRawData playlistData = await cd.ExportPlaylistAsync(_playlist.PlaylistId);
-      PlayItemsModel.CheckQueryPlayAction(() => CollectionUtils.Cluster(playlistData.MediaItemIds, 1000).SelectMany(itemIds =>
+      PlayItemsModel.CheckQueryPlayAction(() => CollectionUtils.Cluster(playlistData.MediaItemIds, 500).SelectMany(itemIds =>
             cd.LoadCustomPlaylistAsync(itemIds, necessaryMIATypes, optionalMIATypes).Result), avType.Value);
     }
 


### PR DESCRIPTION
Reduce chunk size in playlist load request, so SQLite does not hit its hard coded limit on the number of parameters to a SQL statement.
