### PR TITLE
Wip 2.2.1 MP2-198 MP2-199 MP2-200

### DIFF
--- a/MediaPortal/Source/Core/MediaPortal.UI/Presentation/Utilities/IPathBrowser.cs
+++ b/MediaPortal/Source/Core/MediaPortal.UI/Presentation/Utilities/IPathBrowser.cs
@@ -23,6 +23,8 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using MediaPortal.Common.ResourceAccess;
 
 namespace MediaPortal.UI.Presentation.Utilities
@@ -35,6 +37,13 @@ namespace MediaPortal.UI.Presentation.Utilities
   public delegate bool ValidatePathDlgt(ResourcePath path);
 
   /// <summary>
+  /// Validates a file name to see if it should be included (for implementing file filters).
+  /// </summary>
+  /// <param name="path">File to check.</param>
+  /// <returns><c>true</c>, if the file is to be included in the dialog, else <c>false</c>.</returns>
+  public delegate bool ValidateFileDlgt(ResourcePath path);
+
+  /// <summary>
   /// Generic path browser API.
   /// </summary>
   /// <remarks>
@@ -45,5 +54,35 @@ namespace MediaPortal.UI.Presentation.Utilities
   {
     Guid ShowPathBrowser(string headerText, bool enumerateFiles, bool showSystemResources, ValidatePathDlgt validatePathDlgt);
     Guid ShowPathBrowser(string headerText, bool enumerateFiles, bool showSystemResources, ResourcePath initialPath, ValidatePathDlgt validatePathDlgt);
+    Guid ShowPathBrowser(string headerText, bool enumerateFiles, bool showSystemResources, ResourcePath initialPath, ValidatePathDlgt validatePathDlgt, ValidateFileDlgt validateFileDlgt);
+  }
+
+  /// <summary>
+  /// Class to provide a file name filter that only accepts certain extensions (case insensitive)
+  /// </summary>
+  public class FileExtensionFilter {
+    IEnumerable<string> _permittedExtensions;
+
+    /// <summary>
+    /// Call with one parameter per permitted extension.
+    /// NB The extension should contain the leading dot (.) - e.g. ".png"
+    /// </summary>
+    public FileExtensionFilter(params string[] extensions) {
+      _permittedExtensions = extensions;
+    }
+    /// <summary>
+    /// Call with enumerable (List/Array/etc.) of permitted extensions.
+    /// NB The extension should contain the leading dot (.) - e.g. ".png"
+    /// </summary>
+    /// <param name="extensions"></param>
+    public FileExtensionFilter(IEnumerable<string> permittedExtensions) {
+      _permittedExtensions = permittedExtensions;
+    }
+    /// <summary>
+    /// The ValidateFile method matches ValidateFileDlgt
+    /// </summary>
+    public bool ValidateFile(ResourcePath path) {
+      return _permittedExtensions.Any(e => path.FileName.ToLower().EndsWith(e.ToLower()));
+    }
   }
 }

--- a/MediaPortal/Source/Core/MediaPortal.Utilities/MediaPortal.Utilities.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.Utilities/MediaPortal.Utilities.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Network\Netbios\NbNsResourceRecordBase.cs" />
     <Compile Include="Network\Netbios\NbNsStatistics.cs" />
     <Compile Include="Network\Netbios\NbPacketSegmentBase.cs" />
+    <Compile Include="OrdinalStringComparer.cs" />
     <Compile Include="Process\Ipc.cs" />
     <Compile Include="Process\IpcClient.cs" />
     <Compile Include="Process\IpcServer.cs" />

--- a/MediaPortal/Source/Core/MediaPortal.Utilities/OrdinalStringComparer.cs
+++ b/MediaPortal/Source/Core/MediaPortal.Utilities/OrdinalStringComparer.cs
@@ -1,8 +1,33 @@
-﻿using System;
+﻿#region Copyright (C) 2019 Team MediaPortal
+
+/*
+    Copyright (C) 2019 Team MediaPortal
+    http://www.team-mediaportal.com
+
+    This file is part of MediaPortal 2
+
+    MediaPortal 2 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    MediaPortal 2 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MediaPortal 2. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace MediaPortal.Utilities {
+namespace MediaPortal.Utilities
+{
   /// <summary> 
   /// Defines a method that a string implements to compare two values according to their ordinal value (text and number). 
   /// i.e. it sorts the same way a Windows file listing sorts, so that (e.g.) "File 10" is > "File 1"
@@ -10,7 +35,8 @@ namespace MediaPortal.Utilities {
   /// This class implements the <c>IComparer&lt;T&gt;</c> interface with type string. 
   /// Thanks to Stefano Tempesta https://social.msdn.microsoft.com/profile/stefano%20tempesta/ for the initial code.
   /// </summary> 
-  public class OrdinalStringComparer : IComparer<string> {
+  public class OrdinalStringComparer : IComparer<string>
+  {
     private static Regex _numericSplitter = new Regex("([0-9]+)");
     private bool _ignoreCase = true;
 
@@ -18,14 +44,16 @@ namespace MediaPortal.Utilities {
     /// Creates an instance of <c>OrdinalStringComparer</c> for case-insensitive string comparison. 
     /// </summary> 
     public OrdinalStringComparer()
-        : this(true) {
+        : this(true)
+    {
     }
 
     /// <summary> 
     /// Creates an instance of <c>OrdinalStringComparer</c> for case comparison according to the value specified in input. 
     /// </summary> 
     /// <param name="ignoreCase">true to ignore case during the comparison; otherwise, false.</param> 
-    public OrdinalStringComparer(bool ignoreCase) {
+    public OrdinalStringComparer(bool ignoreCase)
+    {
       _ignoreCase = ignoreCase;
     }
 
@@ -35,12 +63,15 @@ namespace MediaPortal.Utilities {
     /// <param name="x">The first string to compare.</param> 
     /// <param name="y">The second string to compare.</param> 
     /// <returns>A signed integer that indicates the relative values of x and y, as in the Compare method in the <c>IComparer&lt;T&gt;</c> interface.</returns> 
-    public int Compare(string x, string y) {
+    public int Compare(string x, string y)
+    {
       // check for null values first: a null reference is considered to be less than any reference that is not null 
-      if (x == null) {
+      if (x == null)
+      {
         return y == null ? 0 : -1;
       }
-      if (y == null) {
+      if (y == null)
+      {
         return 1;
       }
 
@@ -51,19 +82,24 @@ namespace MediaPortal.Utilities {
 
       int comparer = 0;
 
-      for (int i = 0; comparer == 0 && i < splitX.Length; i++) {
+      for (int i = 0; comparer == 0 && i < splitX.Length; i++)
+      {
         if (splitY.Length <= i)
           return 1; // x > y 
 
         int numericX = -1;
         int numericY = -1;
-        if (int.TryParse(splitX[i], out numericX)) {
-          if (int.TryParse(splitY[i], out numericY)) {
+        if (int.TryParse(splitX[i], out numericX))
+        {
+          if (int.TryParse(splitY[i], out numericY))
+          {
             comparer = numericX - numericY;
-          } else {
+          } else
+          {
             return 1; // x > y 
           }
-        } else {
+        } else
+        {
           comparer = String.Compare(splitX[i], splitY[i], comparisonMode);
         }
       }
@@ -72,5 +108,5 @@ namespace MediaPortal.Utilities {
       return comparer;
     }
   }
-} 
+}
 

--- a/MediaPortal/Source/Core/MediaPortal.Utilities/OrdinalStringComparer.cs
+++ b/MediaPortal/Source/Core/MediaPortal.Utilities/OrdinalStringComparer.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace MediaPortal.Utilities {
+  /// <summary> 
+  /// Defines a method that a string implements to compare two values according to their ordinal value (text and number). 
+  /// i.e. it sorts the same way a Windows file listing sorts, so that (e.g.) "File 10" is > "File 1"
+  /// Note that the class emulates the Windows bug/feature that (e.g.) "list 2.txt" sorts BEFORE "list.txt"
+  /// This class implements the <c>IComparer&lt;T&gt;</c> interface with type string. 
+  /// Thanks to Stefano Tempesta https://social.msdn.microsoft.com/profile/stefano%20tempesta/ for the initial code.
+  /// </summary> 
+  public class OrdinalStringComparer : IComparer<string> {
+    private static Regex _numericSplitter = new Regex("([0-9]+)");
+    private bool _ignoreCase = true;
+
+    /// <summary> 
+    /// Creates an instance of <c>OrdinalStringComparer</c> for case-insensitive string comparison. 
+    /// </summary> 
+    public OrdinalStringComparer()
+        : this(true) {
+    }
+
+    /// <summary> 
+    /// Creates an instance of <c>OrdinalStringComparer</c> for case comparison according to the value specified in input. 
+    /// </summary> 
+    /// <param name="ignoreCase">true to ignore case during the comparison; otherwise, false.</param> 
+    public OrdinalStringComparer(bool ignoreCase) {
+      _ignoreCase = ignoreCase;
+    }
+
+    /// <summary> 
+    /// Compares two strings and returns a value indicating whether one is less than, equal to, or greater than the other. 
+    /// </summary> 
+    /// <param name="x">The first string to compare.</param> 
+    /// <param name="y">The second string to compare.</param> 
+    /// <returns>A signed integer that indicates the relative values of x and y, as in the Compare method in the <c>IComparer&lt;T&gt;</c> interface.</returns> 
+    public int Compare(string x, string y) {
+      // check for null values first: a null reference is considered to be less than any reference that is not null 
+      if (x == null) {
+        return y == null ? 0 : -1;
+      }
+      if (y == null) {
+        return 1;
+      }
+
+      StringComparison comparisonMode = _ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
+
+      string[] splitX = _numericSplitter.Split(x.Replace(" ", ""));
+      string[] splitY = _numericSplitter.Split(y.Replace(" ", ""));
+
+      int comparer = 0;
+
+      for (int i = 0; comparer == 0 && i < splitX.Length; i++) {
+        if (splitY.Length <= i)
+          return 1; // x > y 
+
+        int numericX = -1;
+        int numericY = -1;
+        if (int.TryParse(splitX[i], out numericX)) {
+          if (int.TryParse(splitY[i], out numericY)) {
+            comparer = numericX - numericY;
+          } else {
+            return 1; // x > y 
+          }
+        } else {
+          comparer = String.Compare(splitX[i], splitY[i], comparisonMode);
+        }
+      }
+      if (comparer == 0 && splitY.Length > splitX.Length)
+        comparer = -1;
+      return comparer;
+    }
+  }
+} 
+

--- a/MediaPortal/Source/UI/UiComponents/Media/Models/ManagePlaylistsModel.cs
+++ b/MediaPortal/Source/UI/UiComponents/Media/Models/ManagePlaylistsModel.cs
@@ -326,7 +326,7 @@ namespace MediaPortal.UiComponents.Media.Models
       // 1) Load media item ids in the playlist
       // 2) Load media items in clusters - for each cluster, an own query will be executed at the content directory
       PlaylistRawData playlistData = await cd.ExportPlaylistAsync(_playlist.PlaylistId);
-      PlayItemsModel.CheckQueryPlayAction(() => CollectionUtils.Cluster(playlistData.MediaItemIds, 1000).SelectMany(itemIds =>
+      PlayItemsModel.CheckQueryPlayAction(() => CollectionUtils.Cluster(playlistData.MediaItemIds, 500).SelectMany(itemIds =>
             cd.LoadCustomPlaylistAsync(itemIds, necessaryMIATypes, optionalMIATypes).Result), avType.Value);
     }
 

--- a/MediaPortal/Source/UI/UiComponents/SkinBase/Services/PathBrowserService.cs
+++ b/MediaPortal/Source/UI/UiComponents/SkinBase/Services/PathBrowserService.cs
@@ -269,17 +269,17 @@ namespace MediaPortal.UiComponents.SkinBase.Services
       items.Clear();
       IEnumerable<ResourcePathMetadata> res = GetChildDirectoriesData(path);
       if (res != null)
-        AddResources(res, items);
+        AddResources(res, items, true);
       if (_enumerateFiles)
       {
         res = GetFilesData(path);
         if (res != null)
-          AddResources(res, items);
+          AddResources(res, items, false);
       }
       items.FireChange();
     }
 
-    protected void AddResources(IEnumerable<ResourcePathMetadata> resources, ItemsList items)
+    protected void AddResources(IEnumerable<ResourcePathMetadata> resources, ItemsList items, bool isFolder)
     {
       List<ResourcePathMetadata> resourcesMetadata = new List<ResourcePathMetadata>(resources);
       resourcesMetadata.Sort((a, b) => a.ResourceName.CompareTo(b.ResourceName));
@@ -292,6 +292,11 @@ namespace MediaPortal.UiComponents.SkinBase.Services
           directoryItem.Selected = true;
         directoryItem.SelectedProperty.Attach(OnTreePathSelectionChanged);
         directoryItem.AdditionalProperties[Consts.KEY_EXPANSION] = new ExpansionHelper(directoryItem, this);
+        if(isFolder) {
+          // For folders, add a dummy subitem, so HeaderedItemsControl says the item is expandable.
+          // This will be overwritten when the user clicks on the + and OnExpandedChanged is called
+          directoryItem.SubItems.Add(new TreeItem());
+        }
         items.Add(directoryItem);
       }
     }

--- a/MediaPortal/Source/UI/UiComponents/SkinBase/Services/PathBrowserService.cs
+++ b/MediaPortal/Source/UI/UiComponents/SkinBase/Services/PathBrowserService.cs
@@ -300,7 +300,8 @@ namespace MediaPortal.UiComponents.SkinBase.Services
           directoryItem.Selected = true;
         directoryItem.SelectedProperty.Attach(OnTreePathSelectionChanged);
         directoryItem.AdditionalProperties[Consts.KEY_EXPANSION] = new ExpansionHelper(directoryItem, this);
-        if(isFolder) {
+        if (isFolder)
+        {
           // For folders, add a dummy subitem, so HeaderedItemsControl says the item is expandable.
           // This will be overwritten when the user clicks on the + and OnExpandedChanged is called
           directoryItem.SubItems.Add(new TreeItem());
@@ -384,7 +385,8 @@ namespace MediaPortal.UiComponents.SkinBase.Services
       return ShowPathBrowser(headerText, enumerateFiles, showSystemResources, null, validatePathDlgt, null);
     }
 
-    public Guid ShowPathBrowser(string headerText, bool enumerateFiles, bool showSystemResources, ResourcePath initialPath, ValidatePathDlgt validatePathDlgt) {
+    public Guid ShowPathBrowser(string headerText, bool enumerateFiles, bool showSystemResources, ResourcePath initialPath, ValidatePathDlgt validatePathDlgt)
+    {
       return ShowPathBrowser(headerText, enumerateFiles, showSystemResources, initialPath, validatePathDlgt, null);
     }
 

--- a/MediaPortal/Source/UI/UiComponents/SkinBase/Services/PathBrowserService.cs
+++ b/MediaPortal/Source/UI/UiComponents/SkinBase/Services/PathBrowserService.cs
@@ -289,7 +289,8 @@ namespace MediaPortal.UiComponents.SkinBase.Services
     protected void AddResources(IEnumerable<ResourcePathMetadata> resources, ItemsList items, bool isFolder)
     {
       List<ResourcePathMetadata> resourcesMetadata = new List<ResourcePathMetadata>(resources);
-      resourcesMetadata.Sort((a, b) => a.ResourceName.CompareTo(b.ResourceName));
+      MediaPortal.Utilities.OrdinalStringComparer comparer = new Utilities.OrdinalStringComparer(true);
+      resourcesMetadata.Sort((a, b) => comparer.Compare(a.ResourceName, b.ResourceName));
       foreach (ResourcePathMetadata resourceMetadata in resourcesMetadata)
       {
         TreeItem directoryItem = new TreeItem(Consts.KEY_NAME, resourceMetadata.ResourceName);

--- a/MediaPortal/Source/UI/UiComponents/SkinBase/Skin/default/screens/DialogPathBrowser.xaml
+++ b/MediaPortal/Source/UI/UiComponents/SkinBase/Skin/default/screens/DialogPathBrowser.xaml
@@ -25,7 +25,6 @@
         </Grid.ColumnDefinitions>
         <TreeView Grid.Row="0" Style="{ThemeResource SingleMarkableTreeViewStyle}"
             VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
-            ForceExpander="True"
             ItemsSource="{Binding Path=PathTreeRoot,Mode=OneTime}">
           <TreeView.Resources>
             <BindingWrapper x:Key="Expander_Binding" Binding="{Binding Path=AdditionalProperties[Expansion].IsExpanded,Mode=OneWayToSource}"/>

--- a/MediaPortal/Source/UI/UiComponents/Utilities/Models/PlaylistImportModel.cs
+++ b/MediaPortal/Source/UI/UiComponents/Utilities/Models/PlaylistImportModel.cs
@@ -356,7 +356,7 @@ namespace MediaPortal.UiComponents.Utilities.Models
                 return false;
               string extension = StringUtils.TrimToEmpty(DosPathHelper.GetExtension(choosenPath)).ToLowerInvariant();
               return (extension == ".m3u" || extension == ".m3u8") && File.Exists(choosenPath);
-            });
+            }, new FileExtensionFilter(".m3u", ".m3u8").ValidateFile);
       if (_pathBrowserCloseWatcher != null)
         _pathBrowserCloseWatcher.Dispose();
       _pathBrowserCloseWatcher = new PathBrowserCloseWatcher(this, dialogHandle, choosenPath =>


### PR DESCRIPTION
New commits to WIP_2.2.1 branch to fix bugs:

MP2-198 TreeViewControl displays files as expandable.

MP2-199 Playlist import utility allows to browse only for playlist files, but displays other file types, too.

MP2-200 Playlist import: When choosing a file, treeview is not sorted ordinal.

MP2-786 Cannot play playlist with >=1000 entries.
