### PR TITLE
Allow a modern MSBuild (15.8+) to compile the projects

### DIFF
--- a/MediaPortal/Build/Build.proj
+++ b/MediaPortal/Build/Build.proj
@@ -74,8 +74,8 @@
     <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-ServiceMonitor.sln" Condition="$(BuildServiceMonitor) == 'true'" />
     <ProjectsToBuild Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" />
     <!-- x64 solutions -->
-    <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-Client.sln" Condition="$(BuildClient) == 'true'" Properties="Platform=x64" />
-    <ProjectsToBuild Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" Properties="Platform=x64" />
+    <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-Client.sln" Condition="$(BuildClient) == 'true'" AdditionalProperties="Platform=x64" />
+    <ProjectsToBuild Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" AdditionalProperties="Platform=x64" />
     <!-- Setup needs to be built as last -->
     <ProjectsToBuild Include="$(ProjectRoot)\Setup\MP2-Setup.sln" Condition="$(BuildSetup) == 'true'" />
   </ItemGroup>

--- a/MediaPortal/Build/Build.proj
+++ b/MediaPortal/Build/Build.proj
@@ -68,12 +68,15 @@
 
   <!-- This item group holds the MP2 solutions that should actually being built. -->
   <ItemGroup>
-    <ProjectsToBuildX64 Include="$(ProjectRoot)\Source\MP2-Client.sln" Condition="$(BuildClient) == 'true'" />
+    <!-- AnyCPU solutions -->
     <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-Client.sln" Condition="$(BuildClient) == 'true'" />
     <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-Server.sln" Condition="$(BuildServer) == 'true'" />
     <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-ServiceMonitor.sln" Condition="$(BuildServiceMonitor) == 'true'" />
-    <ProjectsToBuildX64 Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" />
     <ProjectsToBuild Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" />
+    <!-- x64 solutions -->
+    <ProjectsToBuild Include="$(ProjectRoot)\Source\MP2-Client.sln" Condition="$(BuildClient) == 'true'" Properties="Platform=x64" />
+    <ProjectsToBuild Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" Properties="Platform=x64" />
+    <!-- Setup needs to be built as last -->
     <ProjectsToBuild Include="$(ProjectRoot)\Setup\MP2-Setup.sln" Condition="$(BuildSetup) == 'true'" />
   </ItemGroup>
 
@@ -117,12 +120,8 @@
   <Target Name="Build"
           DependsOnTargets="@(DependsOnTargets)">
     <MSBuild Projects="@(ProjectsToBuild)"
-             Properties="Configuration=$(Configuration);Platform=$(Platform)"
+             Properties="Configuration=$(Configuration)"
              Targets="Rebuild" />
-
-    <MSBuild Projects="@(ProjectsToBuildX64)"
-             Properties="Configuration=$(Configuration);Platform=x64"
-             Targets="Build" />
   </Target>
 
 </Project>

--- a/MediaPortal/Build/MSBUILD_Rebuild_Base.bat
+++ b/MediaPortal/Build/MSBUILD_Rebuild_Base.bat
@@ -6,6 +6,8 @@ if not exist %MB% set MB="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Commu
 if not exist %MB% set MB="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBUILD.exe"
 if not exist %MB% set MB="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBUILD.exe"
 if not exist %MB% set MB="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBUILD.exe"
+if not exist %MB% set MB="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\MSBuild\16.0\Bin\MSBUILD.exe"
+if not exist %MB% set MB="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBUILD.exe"
 
 if not exist %MB% echo "No supported MSBUILD version found. Exiting here." && exit 1
 echo Start building using %MB%

--- a/MediaPortal/Build/RestorePackages.targets
+++ b/MediaPortal/Build/RestorePackages.targets
@@ -9,13 +9,18 @@
   <PropertyGroup>
     <ProjectRoot Condition="$(ProjectRoot) == ''">$(MSBuildThisFileDirectory)\..</ProjectRoot>
     <NuGetExePath Condition="$(NuGetExePath) == ''">$(MSBuildThisFileDirectory)\NuGet.exe</NuGetExePath>
+    <!-- 
+    Example to force a specific MSBuild version
+    <NuGetMsBuildVersion Condition="$(NuGetMsBuildVersion) == ''">-MSBuildVersion 15.9</NuGetMsBuildVersion>
+	-->
+    <NuGetMsBuildVersion Condition="$(NuGetMsBuildVersion) == ''"></NuGetMsBuildVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectsToRestore Include="$(ProjectRoot)\Source\MP2-Client.sln"/>
     <ProjectsToRestore Include="$(ProjectRoot)\Source\MP2-Server.sln"/>
     <ProjectsToRestore Include="$(ProjectRoot)\Source\MP2-ServiceMonitor.sln"/>
-    <ProjectsToRestore Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln"/>
+    <ProjectsToRestore Include="$(ProjectRoot)\..\OnlineVideos\OnlineVideos.MediaPortal2.sln" Condition="$(BuildOnlineVideos) == 'true'" />
     <ProjectsToRestore Include="$(ProjectRoot)\Setup\MP2-Setup.sln"/>
     <ProjectsToRestore Include="$(ProjectRoot)\Source\UI\Players\EVRPresenter\EVRPresenter.sln"/>
   </ItemGroup>
@@ -30,8 +35,8 @@
     <Message Text="Found the following solutions: @(ProjectsToRestore->'%(FullPath)')"/>
 
     <!-- First do a self update of nuget.exe -->
-    <Exec Command='"$(NuGetExePath)" update -self'/>
-    <Exec Command='"$(NuGetExePath)" restore "%(ProjectsToRestore.FullPath)"'/>
+    <Exec Command='"$(NuGetExePath)" update -self $(NuGetMsBuildVersion)'/>
+    <Exec Command='"$(NuGetExePath)" restore "%(ProjectsToRestore.FullPath)" $(NuGetMsBuildVersion)'/>
   </Target>
 
   <!--
@@ -41,7 +46,7 @@
   <Target Name="RestoreBuildPackages"
           DependsOnTargets="DownloadNuGet">
     <!-- First do a self update of nuget.exe -->
-    <Exec Command='"$(NuGetExePath)" update -self'/>
+    <Exec Command='"$(NuGetExePath)" update -self $(NuGetMsBuildVersion)'/>
     <Exec Command='"$(NuGetExePath)" install "$(MSBuildThisFileDirectory)\packages.config"'/>
   </Target>
 </Project>

--- a/MediaPortal/Incubator/1TrueError/codeRR.csproj
+++ b/MediaPortal/Incubator/1TrueError/codeRR.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.CodeRR</RootNamespace>
     <AssemblyName>codeRR</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Incubator/1TrueError/codeRR.csproj
+++ b/MediaPortal/Incubator/1TrueError/codeRR.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.CodeRR</RootNamespace>
     <AssemblyName>codeRR</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Incubator/AppLauncher/AppLauncher.csproj
+++ b/MediaPortal/Incubator/AppLauncher/AppLauncher.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.AppLauncher</RootNamespace>
     <AssemblyName>AppLauncher</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Incubator/AppLauncher/AppLauncher.csproj
+++ b/MediaPortal/Incubator/AppLauncher/AppLauncher.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.AppLauncher</RootNamespace>
     <AssemblyName>AppLauncher</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Incubator/BluRayPlayer/BluRayPlayer.csproj
+++ b/MediaPortal/Incubator/BluRayPlayer/BluRayPlayer.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UI.Players.Video</RootNamespace>
     <AssemblyName>BluRayPlayer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/MediaPortal/Incubator/BluRayPlayer/BluRayPlayer.csproj
+++ b/MediaPortal/Incubator/BluRayPlayer/BluRayPlayer.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UI.Players.Video</RootNamespace>
     <AssemblyName>BluRayPlayer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/MediaPortal/Incubator/Diagnostics/Diagnostics.csproj
+++ b/MediaPortal/Incubator/Diagnostics/Diagnostics.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.UiComponents.Diagnostics</RootNamespace>
     <AssemblyName>Diagnostics</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/Diagnostics/Diagnostics.csproj
+++ b/MediaPortal/Incubator/Diagnostics/Diagnostics.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.UiComponents.Diagnostics</RootNamespace>
     <AssemblyName>Diagnostics</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/HomeEditor/HomeEditor.csproj
+++ b/MediaPortal/Incubator/HomeEditor/HomeEditor.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>HomeEditor</RootNamespace>
     <AssemblyName>HomeEditor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/HomeEditor/HomeEditor.csproj
+++ b/MediaPortal/Incubator/HomeEditor/HomeEditor.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>HomeEditor</RootNamespace>
     <AssemblyName>HomeEditor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/Login/Login.csproj
+++ b/MediaPortal/Incubator/Login/Login.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Incubator/Login/Login.csproj
+++ b/MediaPortal/Incubator/Login/Login.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Incubator/MediaServer.Client/MediaServer.Client.csproj
+++ b/MediaPortal/Incubator/MediaServer.Client/MediaServer.Client.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MediaServer.Client</RootNamespace>
     <AssemblyName>MediaServer.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/MediaServer.Client/MediaServer.Client.csproj
+++ b/MediaPortal/Incubator/MediaServer.Client/MediaServer.Client.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MediaServer.Client</RootNamespace>
     <AssemblyName>MediaServer.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/MediaServer.Interfaces/MediaServer.Interfaces.csproj
+++ b/MediaPortal/Incubator/MediaServer.Interfaces/MediaServer.Interfaces.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MediaServer.Interfaces</RootNamespace>
     <AssemblyName>MediaServer.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/MediaServer.Interfaces/MediaServer.Interfaces.csproj
+++ b/MediaPortal/Incubator/MediaServer.Interfaces/MediaServer.Interfaces.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MediaServer.Interfaces</RootNamespace>
     <AssemblyName>MediaServer.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/SkinSettings/SkinSettings.csproj
+++ b/MediaPortal/Incubator/SkinSettings/SkinSettings.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>SkinSettings</RootNamespace>
     <AssemblyName>SkinSettings</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/SkinSettings/SkinSettings.csproj
+++ b/MediaPortal/Incubator/SkinSettings/SkinSettings.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>SkinSettings</RootNamespace>
     <AssemblyName>SkinSettings</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/TranscodingService.Client/TranscodingService.Client.csproj
+++ b/MediaPortal/Incubator/TranscodingService.Client/TranscodingService.Client.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.TranscodingService.Client</RootNamespace>
     <AssemblyName>TranscodingService.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/TranscodingService.Client/TranscodingService.Client.csproj
+++ b/MediaPortal/Incubator/TranscodingService.Client/TranscodingService.Client.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.TranscodingService.Client</RootNamespace>
     <AssemblyName>TranscodingService.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Incubator/TranscodingService.Interfaces/TranscodingService.Interfaces.csproj
+++ b/MediaPortal/Incubator/TranscodingService.Interfaces/TranscodingService.Interfaces.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.TranscodingService.Interfaces</RootNamespace>
     <AssemblyName>TranscodingService.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Incubator/TranscodingService.Interfaces/TranscodingService.Interfaces.csproj
+++ b/MediaPortal/Incubator/TranscodingService.Interfaces/TranscodingService.Interfaces.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.TranscodingService.Interfaces</RootNamespace>
     <AssemblyName>TranscodingService.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Incubator/UPnPRenderer/UPnPRenderer.csproj
+++ b/MediaPortal/Incubator/UPnPRenderer/UPnPRenderer.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Incubator/UPnPRenderer/UPnPRenderer.csproj
+++ b/MediaPortal/Incubator/UPnPRenderer/UPnPRenderer.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Client/WakeOnLan.Client.csproj
+++ b/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Client/WakeOnLan.Client.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>WakeOnLan.Client</RootNamespace>
     <AssemblyName>WakeOnLan.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Client/WakeOnLan.Client.csproj
+++ b/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Client/WakeOnLan.Client.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>WakeOnLan.Client</RootNamespace>
     <AssemblyName>WakeOnLan.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Common/WakeOnLan.Common.csproj
+++ b/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Common/WakeOnLan.Common.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>WakeOnLan.Common</RootNamespace>
     <AssemblyName>WakeOnLan.Common</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Common/WakeOnLan.Common.csproj
+++ b/MediaPortal/Incubator/WakeOnLan/WakeOnLan.Common/WakeOnLan.Common.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>WakeOnLan.Common</RootNamespace>
     <AssemblyName>WakeOnLan.Common</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Incubator/WifiRemote/WifiRemote.csproj
+++ b/MediaPortal/Incubator/WifiRemote/WifiRemote.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.WifiRemote</RootNamespace>
     <AssemblyName>WifiRemote</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Incubator/WifiRemote/WifiRemote.csproj
+++ b/MediaPortal/Incubator/WifiRemote/WifiRemote.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.WifiRemote</RootNamespace>
     <AssemblyName>WifiRemote</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Resources/CodeTestPlugin/CodeTestPlugin.csproj
+++ b/MediaPortal/Resources/CodeTestPlugin/CodeTestPlugin.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Resources/CodeTestPlugin/CodeTestPlugin.csproj
+++ b/MediaPortal/Resources/CodeTestPlugin/CodeTestPlugin.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Resources/Examples/HelloWorldExamplePlugin/HelloWorld.csproj
+++ b/MediaPortal/Resources/Examples/HelloWorldExamplePlugin/HelloWorld.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Resources/Examples/HelloWorldExamplePlugin/HelloWorld.csproj
+++ b/MediaPortal/Resources/Examples/HelloWorldExamplePlugin/HelloWorld.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Resources/GUITestPlugin/GUITestPlugin.csproj
+++ b/MediaPortal/Resources/GUITestPlugin/GUITestPlugin.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Resources/GUITestPlugin/GUITestPlugin.csproj
+++ b/MediaPortal/Resources/GUITestPlugin/GUITestPlugin.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Resources/HelperPlugins/SkinHelper/SkinHelper.csproj
+++ b/MediaPortal/Resources/HelperPlugins/SkinHelper/SkinHelper.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Helpers.SkinHelper</RootNamespace>
     <AssemblyName>SkinHelper</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Resources/HelperPlugins/SkinHelper/SkinHelper.csproj
+++ b/MediaPortal/Resources/HelperPlugins/SkinHelper/SkinHelper.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Helpers.SkinHelper</RootNamespace>
     <AssemblyName>SkinHelper</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Resources/Settings/ReSharper/TeamMediaPortal.DotSettings
+++ b/MediaPortal/Resources/Settings/ReSharper/TeamMediaPortal.DotSettings
@@ -67,6 +67,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MODIFIERS_ORDER/@EntryValue">public protected internal private new abstract virtual override sealed static readonly extern unsafe volatile async</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ABSTRACT_ACCESSORHOLDER_ON_SINGLE_LINE/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_WITH_ATTRS_HOLDER_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CATCH_ON_NEW_LINE/@EntryValue">True</s:Boolean>
@@ -227,7 +228,12 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=f3b4c4c3_002D5ae8_002D47fd_002D8cde_002D9a05099b24cb/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Instance" AccessRightKinds="Protected" Description=""&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Client/ServerSettings.Client.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Client/ServerSettings.Client.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerSettings</RootNamespace>
     <AssemblyName>ServerSettings.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Client/ServerSettings.Client.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Client/ServerSettings.Client.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerSettings</RootNamespace>
     <AssemblyName>ServerSettings.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Interfaces/ServerSettings.Interfaces.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Interfaces/ServerSettings.Interfaces.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerSettings</RootNamespace>
     <AssemblyName>ServerSettings.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Interfaces/ServerSettings.Interfaces.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerSettings.Interfaces/ServerSettings.Interfaces.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerSettings</RootNamespace>
     <AssemblyName>ServerSettings.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Client/ServerStateService.Client.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Client/ServerStateService.Client.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerStateService.Client</RootNamespace>
     <AssemblyName>ServerStateService.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Client/ServerStateService.Client.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Client/ServerStateService.Client.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerStateService.Client</RootNamespace>
     <AssemblyName>ServerStateService.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Interfaces/ServerStateService.Interfaces.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Interfaces/ServerStateService.Interfaces.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerStateService.Interfaces</RootNamespace>
     <AssemblyName>ServerStateService.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Interfaces/ServerStateService.Interfaces.csproj
+++ b/MediaPortal/Source/Backend/BackendComponents/ServerStateService/ServerStateService.Interfaces/ServerStateService.Interfaces.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.ServerStateService.Interfaces</RootNamespace>
     <AssemblyName>ServerStateService.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/Core/ConfigurationManager/ConfigurationManager.csproj
+++ b/MediaPortal/Source/Core/ConfigurationManager/ConfigurationManager.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/Core/ConfigurationManager/ConfigurationManager.csproj
+++ b/MediaPortal/Source/Core/ConfigurationManager/ConfigurationManager.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/Core/MediaPortal.Common/MediaPortal.Common.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.Common/MediaPortal.Common.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Source/Core/MediaPortal.Common/MediaPortal.Common.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.Common/MediaPortal.Common.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Source/Core/MediaPortal.UI/MediaPortal.UI.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.UI/MediaPortal.UI.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/Core/MediaPortal.UI/MediaPortal.UI.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.UI/MediaPortal.UI.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/Core/MediaPortal.Utilities/MediaPortal.Utilities.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.Utilities/MediaPortal.Utilities.csproj
@@ -18,7 +18,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/Core/MediaPortal.Utilities/MediaPortal.Utilities.csproj
+++ b/MediaPortal/Source/Core/MediaPortal.Utilities/MediaPortal.Utilities.csproj
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/Core/UPnP/UPnP.csproj
+++ b/MediaPortal/Source/Core/UPnP/UPnP.csproj
@@ -21,7 +21,7 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>

--- a/MediaPortal/Source/Core/UPnP/UPnP.csproj
+++ b/MediaPortal/Source/Core/UPnP/UPnP.csproj
@@ -21,6 +21,7 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/BassLibraries/BassLibraries.csproj
+++ b/MediaPortal/Source/Extensions/BassLibraries/BassLibraries.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/BassLibraries/BassLibraries.csproj
+++ b/MediaPortal/Source/Extensions/BassLibraries/BassLibraries.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/AudioMetadataExtractor/AudioMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/AudioMetadataExtractor/AudioMetadataExtractor.csproj
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/AudioMetadataExtractor/AudioMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/AudioMetadataExtractor/AudioMetadataExtractor.csproj
@@ -18,7 +18,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/BassAudioMetadataExtractor/BassAudioMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/BassAudioMetadataExtractor/BassAudioMetadataExtractor.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.BassAudioMetadataExtractor</RootNamespace>
     <AssemblyName>BassAudioMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>44373f7d</NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/BassAudioMetadataExtractor/BassAudioMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/BassAudioMetadataExtractor/BassAudioMetadataExtractor.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.BassAudioMetadataExtractor</RootNamespace>
     <AssemblyName>BassAudioMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>44373f7d</NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/BluRayMetadaExtractor/BluRayMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/BluRayMetadaExtractor/BluRayMetadataExtractor.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.BluRayMetadataExtractor</RootNamespace>
     <AssemblyName>BluRayMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/BluRayMetadaExtractor/BluRayMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/BluRayMetadaExtractor/BluRayMetadataExtractor.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.BluRayMetadataExtractor</RootNamespace>
     <AssemblyName>BluRayMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/FFMpegLib/FFMpegLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/FFMpegLib/FFMpegLib.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.FFMpegLib</RootNamespace>
     <AssemblyName>FFMpegLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/FFMpegLib/FFMpegLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/FFMpegLib/FFMpegLib.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.FFMpegLib</RootNamespace>
     <AssemblyName>FFMpegLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/FreeImageLib/FreeImageLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/FreeImageLib/FreeImageLib.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>FreeImageLib</RootNamespace>
     <AssemblyName>FreeImageLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/FreeImageLib/FreeImageLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/FreeImageLib/FreeImageLib.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>FreeImageLib</RootNamespace>
     <AssemblyName>FreeImageLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/GDIThumbnailProvider/GDIThumbnailProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/GDIThumbnailProvider/GDIThumbnailProvider.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.GDIThumbnailProvider</RootNamespace>
     <AssemblyName>GDIThumbnailProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/GDIThumbnailProvider/GDIThumbnailProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/GDIThumbnailProvider/GDIThumbnailProvider.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.GDIThumbnailProvider</RootNamespace>
     <AssemblyName>GDIThumbnailProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/GenreProvider/GenreProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/GenreProvider/GenreProvider.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.GenreProvider</RootNamespace>
     <AssemblyName>GenreProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/Extensions/MetadataExtractors/GenreProvider/GenreProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/GenreProvider/GenreProvider.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.GenreProvider</RootNamespace>
     <AssemblyName>GenreProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/Extensions/MetadataExtractors/ImageMetadataExtractor/ImageMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/ImageMetadataExtractor/ImageMetadataExtractor.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/ImageMetadataExtractor/ImageMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/ImageMetadataExtractor/ImageMetadataExtractor.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MatroskaLib/MatroskaLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MatroskaLib/MatroskaLib.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.MatroskaLib</RootNamespace>
     <AssemblyName>MatroskaLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MatroskaLib/MatroskaLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MatroskaLib/MatroskaLib.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.MatroskaLib</RootNamespace>
     <AssemblyName>MatroskaLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MediaInfoLib/MediaInfoLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MediaInfoLib/MediaInfoLib.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaInfoLib</RootNamespace>
     <AssemblyName>MediaInfoLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <StartupObject>
     </StartupObject>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MediaInfoLib/MediaInfoLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MediaInfoLib/MediaInfoLib.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaInfoLib</RootNamespace>
     <AssemblyName>MediaInfoLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <StartupObject>
     </StartupObject>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor</RootNamespace>
     <AssemblyName>MovieMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/MovieMetadataExtractor/MovieMetadataExtractor.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.MovieMetadataExtractor</RootNamespace>
     <AssemblyName>MovieMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/NfoMetadataExtractors/NfoMetadataExtractors.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/NfoMetadataExtractors/NfoMetadataExtractors.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.NfoMetadataExtractors</RootNamespace>
     <AssemblyName>NfoMetadataExtractors</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/NfoMetadataExtractors/NfoMetadataExtractors.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/NfoMetadataExtractors/NfoMetadataExtractors.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.NfoMetadataExtractors</RootNamespace>
     <AssemblyName>NfoMetadataExtractors</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/OCVVideoThumbnailer/OCVVideoThumbnailer.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/OCVVideoThumbnailer/OCVVideoThumbnailer.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.OCVVideoThumbnailer</RootNamespace>
     <AssemblyName>OCVVideoThumbnailer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/OCVVideoThumbnailer/OCVVideoThumbnailer.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/OCVVideoThumbnailer/OCVVideoThumbnailer.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.OCVVideoThumbnailer</RootNamespace>
     <AssemblyName>OCVVideoThumbnailer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/OnlineLibraries/OnlineLibraries.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/OnlineLibraries/OnlineLibraries.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.OnlineLibraries</RootNamespace>
     <AssemblyName>OnlineLibraries</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/OnlineLibraries/OnlineLibraries.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/OnlineLibraries/OnlineLibraries.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.OnlineLibraries</RootNamespace>
     <AssemblyName>OnlineLibraries</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/OpenCvLib/OpenCvLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/OpenCvLib/OpenCvLib.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>OpenCvLib</RootNamespace>
     <AssemblyName>OpenCvLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/OpenCvLib/OpenCvLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/OpenCvLib/OpenCvLib.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>OpenCvLib</RootNamespace>
     <AssemblyName>OpenCvLib</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/ScriptableMetadataExtractor/ScriptableMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/ScriptableMetadataExtractor/ScriptableMetadataExtractor.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.ScriptableMetadataExtractor</RootNamespace>
     <AssemblyName>ScriptableMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/ScriptableMetadataExtractor/ScriptableMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/ScriptableMetadataExtractor/ScriptableMetadataExtractor.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.ScriptableMetadataExtractor</RootNamespace>
     <AssemblyName>ScriptableMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor</RootNamespace>
     <AssemblyName>SeriesMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SeriesMetadataExtractor/SeriesMetadataExtractor.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.SeriesMetadataExtractor</RootNamespace>
     <AssemblyName>SeriesMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/StubMetadataExtractors/StubMetadataExtractors.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/StubMetadataExtractors/StubMetadataExtractors.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.StubMetadataExtractors</RootNamespace>
     <AssemblyName>StubMetadataExtractors</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/StubMetadataExtractors/StubMetadataExtractors.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/StubMetadataExtractors/StubMetadataExtractors.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.StubMetadataExtractors</RootNamespace>
     <AssemblyName>StubMetadataExtractors</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleDownloaderProvider/SubtitleDownloaderProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleDownloaderProvider/SubtitleDownloaderProvider.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.SubtitleDownloaderProvider</RootNamespace>
     <AssemblyName>SubtitleDownloaderProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleDownloaderProvider/SubtitleDownloaderProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleDownloaderProvider/SubtitleDownloaderProvider.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.SubtitleDownloaderProvider</RootNamespace>
     <AssemblyName>SubtitleDownloaderProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleMetadataExtractor/SubtitleMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleMetadataExtractor/SubtitleMetadataExtractor.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.SubtitleMetadataExtractor</RootNamespace>
     <AssemblyName>SubtitleMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleMetadataExtractor/SubtitleMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/SubtitleMetadataExtractor/SubtitleMetadataExtractor.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.SubtitleMetadataExtractor</RootNamespace>
     <AssemblyName>SubtitleMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/TagLib/TagLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/TagLib/TagLib.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4CC18776-125E-4318-9D24-D60110AD9697}</ProjectGuid>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/TagLib/TagLib.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/TagLib/TagLib.csproj
@@ -9,6 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4CC18776-125E-4318-9D24-D60110AD9697}</ProjectGuid>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/Tve3RecordingMetadataExtractor/Tve3RecordingMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/Tve3RecordingMetadataExtractor/Tve3RecordingMetadataExtractor.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors</RootNamespace>
     <AssemblyName>Tve3RecordingMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/Tve3RecordingMetadataExtractor/Tve3RecordingMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/Tve3RecordingMetadataExtractor/Tve3RecordingMetadataExtractor.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors</RootNamespace>
     <AssemblyName>Tve3RecordingMetadataExtractor</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/VideoMetadataExtractor/VideoMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/VideoMetadataExtractor/VideoMetadataExtractor.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/VideoMetadataExtractor/VideoMetadataExtractor.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/VideoMetadataExtractor/VideoMetadataExtractor.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/VideoThumbnailer/VideoThumbnailer.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/VideoThumbnailer/VideoThumbnailer.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.VideoThumbnailer</RootNamespace>
     <AssemblyName>VideoThumbnailer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/VideoThumbnailer/VideoThumbnailer.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/VideoThumbnailer/VideoThumbnailer.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.VideoThumbnailer</RootNamespace>
     <AssemblyName>VideoThumbnailer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/WICThumbnailProvider/WICThumbnailProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/WICThumbnailProvider/WICThumbnailProvider.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.WICThumbnailProvider</RootNamespace>
     <AssemblyName>WICThumbnailProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/MetadataExtractors/WICThumbnailProvider/WICThumbnailProvider.csproj
+++ b/MediaPortal/Source/Extensions/MetadataExtractors/WICThumbnailProvider/WICThumbnailProvider.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Extensions.MetadataExtractors.WICThumbnailProvider</RootNamespace>
     <AssemblyName>WICThumbnailProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/ResourceProviders/AudioCDResourceProvider/AudioCDResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/AudioCDResourceProvider/AudioCDResourceProvider.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.AudioCDResourceProvider</RootNamespace>
     <AssemblyName>AudioCDResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/ResourceProviders/AudioCDResourceProvider/AudioCDResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/AudioCDResourceProvider/AudioCDResourceProvider.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.AudioCDResourceProvider</RootNamespace>
     <AssemblyName>AudioCDResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/ResourceProviders/IsoResourceProvider/IsoResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/IsoResourceProvider/IsoResourceProvider.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.IsoResourceProvider</RootNamespace>
     <AssemblyName>IsoResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/ResourceProviders/IsoResourceProvider/IsoResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/IsoResourceProvider/IsoResourceProvider.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.IsoResourceProvider</RootNamespace>
     <AssemblyName>IsoResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/ResourceProviders/NetworkNeighborhoodResourceProvider/NetworkNeighborhoodResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/NetworkNeighborhoodResourceProvider/NetworkNeighborhoodResourceProvider.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.NetworkNeighborhoodResourceProvider</RootNamespace>
     <AssemblyName>NetworkNeighborhoodResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/ResourceProviders/NetworkNeighborhoodResourceProvider/NetworkNeighborhoodResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/NetworkNeighborhoodResourceProvider/NetworkNeighborhoodResourceProvider.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.NetworkNeighborhoodResourceProvider</RootNamespace>
     <AssemblyName>NetworkNeighborhoodResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/Extensions/ResourceProviders/ZipResourceProvider/ZipResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/ZipResourceProvider/ZipResourceProvider.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.ZipResourceProvider</RootNamespace>
     <AssemblyName>ZipResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Extensions/ResourceProviders/ZipResourceProvider/ZipResourceProvider.csproj
+++ b/MediaPortal/Source/Extensions/ResourceProviders/ZipResourceProvider/ZipResourceProvider.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.ResourceProviders.ZipResourceProvider</RootNamespace>
     <AssemblyName>ZipResourceProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/Main/MediaPortal.Client/MediaPortal.Client.csproj
+++ b/MediaPortal/Source/Main/MediaPortal.Client/MediaPortal.Client.csproj
@@ -17,6 +17,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <StartupObject>MediaPortal.Client.ApplicationLauncher</StartupObject>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
@@ -31,7 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>true</UseVSHostingProcess>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -41,7 +41,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +50,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -60,7 +58,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/MediaPortal/Source/Main/MediaPortal.Client/MediaPortal.Client.csproj
+++ b/MediaPortal/Source/Main/MediaPortal.Client/MediaPortal.Client.csproj
@@ -32,6 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>true</UseVSHostingProcess>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -41,6 +42,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -50,6 +52,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -58,6 +61,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/MediaPortal/Source/Main/MediaPortal.ClientLauncher/MediaPortal.Client.Launcher.csproj
+++ b/MediaPortal/Source/Main/MediaPortal.ClientLauncher/MediaPortal.Client.Launcher.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Client.Launcher</RootNamespace>
     <AssemblyName>MP2-ClientLauncher</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>MP2.ico</ApplicationIcon>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>

--- a/MediaPortal/Source/Main/MediaPortal.ClientLauncher/MediaPortal.Client.Launcher.csproj
+++ b/MediaPortal/Source/Main/MediaPortal.ClientLauncher/MediaPortal.Client.Launcher.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Client.Launcher</RootNamespace>
     <AssemblyName>MP2-ClientLauncher</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>MP2.ico</ApplicationIcon>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>

--- a/MediaPortal/Source/UI/FanArt/FanArtService.Client/FanArtService.Client.csproj
+++ b/MediaPortal/Source/UI/FanArt/FanArtService.Client/FanArtService.Client.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.UserServices.FanArtService.Client</RootNamespace>
     <AssemblyName>FanArtService.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/FanArt/FanArtService.Client/FanArtService.Client.csproj
+++ b/MediaPortal/Source/UI/FanArt/FanArtService.Client/FanArtService.Client.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.UserServices.FanArtService.Client</RootNamespace>
     <AssemblyName>FanArtService.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/FanArt/FanArtService.Interfaces/FanArtService.Interfaces.csproj
+++ b/MediaPortal/Source/UI/FanArt/FanArtService.Interfaces/FanArtService.Interfaces.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.UserServices.FanArtService.Interfaces</RootNamespace>
     <AssemblyName>FanArtService.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/MediaPortal/Source/UI/FanArt/FanArtService.Interfaces/FanArtService.Interfaces.csproj
+++ b/MediaPortal/Source/UI/FanArt/FanArtService.Interfaces/FanArtService.Interfaces.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Extensions.UserServices.FanArtService.Interfaces</RootNamespace>
     <AssemblyName>FanArtService.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/MediaPortal/Source/UI/Input/InputDeviceManager/InputDeviceManager.csproj
+++ b/MediaPortal/Source/UI/Input/InputDeviceManager/InputDeviceManager.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.InputDeviceManager</RootNamespace>
     <AssemblyName>InputDeviceManager</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Input/InputDeviceManager/InputDeviceManager.csproj
+++ b/MediaPortal/Source/UI/Input/InputDeviceManager/InputDeviceManager.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.InputDeviceManager</RootNamespace>
     <AssemblyName>InputDeviceManager</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Input/IrInput/IrInput.csproj
+++ b/MediaPortal/Source/UI/Input/IrInput/IrInput.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/Input/IrInput/IrInput.csproj
+++ b/MediaPortal/Source/UI/Input/IrInput/IrInput.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/Input/MceRemoteReceiver/MceRemoteReceiver.csproj
+++ b/MediaPortal/Source/UI/Input/MceRemoteReceiver/MceRemoteReceiver.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.MceRemoteReceiver</RootNamespace>
     <AssemblyName>MceRemoteReceiver</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Input/MceRemoteReceiver/MceRemoteReceiver.csproj
+++ b/MediaPortal/Source/UI/Input/MceRemoteReceiver/MceRemoteReceiver.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.MceRemoteReceiver</RootNamespace>
     <AssemblyName>MceRemoteReceiver</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Players/BDHandler/BDHandler.csproj
+++ b/MediaPortal/Source/UI/Players/BDHandler/BDHandler.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.BDHandler</RootNamespace>
     <AssemblyName>BDHandler</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/Players/BDHandler/BDHandler.csproj
+++ b/MediaPortal/Source/UI/Players/BDHandler/BDHandler.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.BDHandler</RootNamespace>
     <AssemblyName>BDHandler</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/Players/BassPlayer/BassPlayer.csproj
+++ b/MediaPortal/Source/UI/Players/BassPlayer/BassPlayer.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>893ff3f1</NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Players/BassPlayer/BassPlayer.csproj
+++ b/MediaPortal/Source/UI/Players/BassPlayer/BassPlayer.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>893ff3f1</NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Players/DirectShowWrapper/DirectShowWrapper.csproj
+++ b/MediaPortal/Source/UI/Players/DirectShowWrapper/DirectShowWrapper.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>DirectShowWrapper</RootNamespace>
     <AssemblyName>DirectShowWrapper</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Players/DirectShowWrapper/DirectShowWrapper.csproj
+++ b/MediaPortal/Source/UI/Players/DirectShowWrapper/DirectShowWrapper.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DirectShowWrapper</RootNamespace>
     <AssemblyName>DirectShowWrapper</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Players/DotNetStreamSource/DotNetStreamSource.csproj
+++ b/MediaPortal/Source/UI/Players/DotNetStreamSource/DotNetStreamSource.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DotNetStreamSource</RootNamespace>
     <AssemblyName>DotNetStreamSource</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Players/DotNetStreamSource/DotNetStreamSource.csproj
+++ b/MediaPortal/Source/UI/Players/DotNetStreamSource/DotNetStreamSource.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>DotNetStreamSource</RootNamespace>
     <AssemblyName>DotNetStreamSource</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/Players/ImagePlayer/ImagePlayer.csproj
+++ b/MediaPortal/Source/UI/Players/ImagePlayer/ImagePlayer.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Players/ImagePlayer/ImagePlayer.csproj
+++ b/MediaPortal/Source/UI/Players/ImagePlayer/ImagePlayer.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Players/RefreshRateChanger/RefreshRateChanger.csproj
+++ b/MediaPortal/Source/UI/Players/RefreshRateChanger/RefreshRateChanger.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.RefreshRateChanger</RootNamespace>
     <AssemblyName>RefreshRateChanger</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/UI/Players/RefreshRateChanger/RefreshRateChanger.csproj
+++ b/MediaPortal/Source/UI/Players/RefreshRateChanger/RefreshRateChanger.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.Plugins.RefreshRateChanger</RootNamespace>
     <AssemblyName>RefreshRateChanger</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/MediaPortal/Source/UI/Players/VideoEffectChanger/VideoEffectChanger.csproj
+++ b/MediaPortal/Source/UI/Players/VideoEffectChanger/VideoEffectChanger.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.UiComponents.VideoEffectChanger</RootNamespace>
     <AssemblyName>VideoEffectChanger</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Players/VideoEffectChanger/VideoEffectChanger.csproj
+++ b/MediaPortal/Source/UI/Players/VideoEffectChanger/VideoEffectChanger.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.UiComponents.VideoEffectChanger</RootNamespace>
     <AssemblyName>VideoEffectChanger</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Players/VideoPlayer/Subtitles/MpcEngine.cs
+++ b/MediaPortal/Source/UI/Players/VideoPlayer/Subtitles/MpcEngine.cs
@@ -27,7 +27,8 @@ using System.Runtime.InteropServices;
 using DirectShow;
 using MediaPortal.UI.Players.Video.Settings;
 using MediaPortal.Utilities.SystemAPI;
-using SharpDX;
+using Rectangle = SharpDX.Rectangle;
+using Size = SharpDX.Size2;
 
 namespace MediaPortal.UI.Players.Video.Subtitles
 {
@@ -46,8 +47,12 @@ namespace MediaPortal.UI.Players.Video.Subtitles
 
     //load subtitles for video file filename, with given (rendered) graph 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, CharSet = CharSet.Unicode)]
-    public static extern bool LoadSubtitles(IntPtr d3DDev, Size2 size, string filename, IGraphBuilder graphBuilder,
+    public static extern bool LoadSubtitles(IntPtr d3DDev, Size size, string filename, IGraphBuilder graphBuilder,
                                             string paths, int lcidCI);
+
+    //updates used D3D device
+    [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, CharSet = CharSet.Unicode)]
+    public static extern bool SetDevice(IntPtr d3DDev);
 
     //set sample time (set from EVR presenter, not used in case of vmr9)
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -80,13 +85,19 @@ namespace MediaPortal.UI.Players.Video.Subtitles
     public static extern void SetCurrent(int current);
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern void SetCurrent3DSubtitle(int current);
+
+    [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern bool GetEnable();
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern void SetEnable(bool enable);
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern void Render(int x, int y, int width, int height);
+    public static extern void Render(int x, int y, int width, int height, int xOffsetInPixels);
+
+    [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern void RenderEx(Rectangle viewportRect, Rectangle croppedVideoRect, int xOffsetInPixels, bool posRelativeToFrame);
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern int GetDelay();
@@ -94,13 +105,13 @@ namespace MediaPortal.UI.Players.Video.Subtitles
     //in milliseconds
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern void SetDelay(int delay_ms);
+    public static extern void SetDelay(int delayMs);
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern void FreeSubtitles();
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern void SetAdvancedOptions(int subPicsBufferAhead, Size2 textureSize, bool pow2tex,
+    public static extern void SetAdvancedOptions(int subPicsBufferAhead, Size textureSize, bool pow2tex,
                                                  bool disableAnimation);
 
     [DllImport("mpcSubs.dll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/MediaPortal/Source/UI/Players/VideoPlayer/Subtitles/MpcSubsRenderer.cs
+++ b/MediaPortal/Source/UI/Players/VideoPlayer/Subtitles/MpcSubsRenderer.cs
@@ -58,7 +58,8 @@ namespace MediaPortal.UI.Players.Video.Subtitles
             if (clear)
               SkinContext.Device.Clear(ClearFlags.Target, ColorConverter.FromArgb(0, Color.Black), 1.0f, 0);
             var surfaceDesc = targetTexture.GetLevelDescription(0);
-            MpcSubtitles.Render(0, 0, surfaceDesc.Width, surfaceDesc.Height);
+            int xOffsetInPixels = 0; // TODO?
+            MpcSubtitles.Render(0, 0, surfaceDesc.Width, surfaceDesc.Height, xOffsetInPixels);
           }
         }
         if (_onTextureInvalidated != null)

--- a/MediaPortal/Source/UI/Players/VideoPlayer/VideoPlayers.csproj
+++ b/MediaPortal/Source/UI/Players/VideoPlayer/VideoPlayers.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UI.Players.Video</RootNamespace>
     <AssemblyName>VideoPlayers</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/Players/VideoPlayer/VideoPlayers.csproj
+++ b/MediaPortal/Source/UI/Players/VideoPlayer/VideoPlayers.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UI.Players.Video</RootNamespace>
     <AssemblyName>VideoPlayers</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/SkinEngine/SkinEngine.csproj
+++ b/MediaPortal/Source/UI/SkinEngine/SkinEngine.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/SkinEngine/SkinEngine.csproj
+++ b/MediaPortal/Source/UI/SkinEngine/SkinEngine.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/Skins/BlueVision/BlueVision.csproj
+++ b/MediaPortal/Source/UI/Skins/BlueVision/BlueVision.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.BlueVision</RootNamespace>
     <AssemblyName>BlueVision</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/UI/Skins/BlueVision/BlueVision.csproj
+++ b/MediaPortal/Source/UI/Skins/BlueVision/BlueVision.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.BlueVision</RootNamespace>
     <AssemblyName>BlueVision</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/UI/Skins/Nereus/Nereus.csproj
+++ b/MediaPortal/Source/UI/Skins/Nereus/Nereus.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.Nereus</RootNamespace>
     <AssemblyName>Nereus</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/Skins/Nereus/Nereus.csproj
+++ b/MediaPortal/Source/UI/Skins/Nereus/Nereus.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.Nereus</RootNamespace>
     <AssemblyName>Nereus</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/Skins/Titanium Extended/Titanium Extended.csproj
+++ b/MediaPortal/Source/UI/Skins/Titanium Extended/Titanium Extended.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.BlueVision</RootNamespace>
     <AssemblyName>BlueVision</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/UI/Skins/Titanium Extended/Titanium Extended.csproj
+++ b/MediaPortal/Source/UI/Skins/Titanium Extended/Titanium Extended.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.BlueVision</RootNamespace>
     <AssemblyName>BlueVision</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>

--- a/MediaPortal/Source/UI/Skins/WMC/WMCSkin.csproj
+++ b/MediaPortal/Source/UI/Skins/WMC/WMCSkin.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.WMCSkin</RootNamespace>
     <AssemblyName>WMCSkin</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/Skins/WMC/WMCSkin.csproj
+++ b/MediaPortal/Source/UI/Skins/WMC/WMCSkin.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.WMCSkin</RootNamespace>
     <AssemblyName>WMCSkin</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTVMPExtendedProvider/SlimTv.MPExtendedProvider.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTVMPExtendedProvider/SlimTv.MPExtendedProvider.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Providers</RootNamespace>
     <AssemblyName>SlimTv.MPExtendedProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTVMPExtendedProvider/SlimTv.MPExtendedProvider.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTVMPExtendedProvider/SlimTv.MPExtendedProvider.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Providers</RootNamespace>
     <AssemblyName>SlimTv.MPExtendedProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTvClient/SlimTv.Client.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTvClient/SlimTv.Client.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Client</RootNamespace>
     <AssemblyName>SlimTv.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTvClient/SlimTv.Client.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTvClient/SlimTv.Client.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Client</RootNamespace>
     <AssemblyName>SlimTv.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTvInterfaces/SlimTv.Interfaces.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTvInterfaces/SlimTv.Interfaces.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Interfaces</RootNamespace>
     <AssemblyName>SlimTv.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTvInterfaces/SlimTv.Interfaces.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTvInterfaces/SlimTv.Interfaces.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Interfaces</RootNamespace>
     <AssemblyName>SlimTv.Interfaces</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/TV/SlimTvNativeProvider/SlimTv.NativeProvider.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTvNativeProvider/SlimTv.NativeProvider.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Providers</RootNamespace>
     <AssemblyName>SlimTv.NativeProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/TV/SlimTvNativeProvider/SlimTv.NativeProvider.csproj
+++ b/MediaPortal/Source/UI/TV/SlimTvNativeProvider/SlimTv.NativeProvider.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SlimTv.Providers</RootNamespace>
     <AssemblyName>SlimTv.NativeProvider</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/BackgroundManager/BackgroundManager.csproj
+++ b/MediaPortal/Source/UI/UiComponents/BackgroundManager/BackgroundManager.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.BackgroundManager</RootNamespace>
     <AssemblyName>BackgroundManager</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <StartupObject>
     </StartupObject>

--- a/MediaPortal/Source/UI/UiComponents/BackgroundManager/BackgroundManager.csproj
+++ b/MediaPortal/Source/UI/UiComponents/BackgroundManager/BackgroundManager.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.BackgroundManager</RootNamespace>
     <AssemblyName>BackgroundManager</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <StartupObject>
     </StartupObject>

--- a/MediaPortal/Source/UI/UiComponents/Configuration/Configuration.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Configuration/Configuration.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.Configuration</RootNamespace>
     <AssemblyName>Configuration</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/UiComponents/Configuration/Configuration.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Configuration/Configuration.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.Configuration</RootNamespace>
     <AssemblyName>Configuration</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Media/Media.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/News/News.csproj
+++ b/MediaPortal/Source/UI/UiComponents/News/News.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.News</RootNamespace>
     <AssemblyName>News</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/News/News.csproj
+++ b/MediaPortal/Source/UI/UiComponents/News/News.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.News</RootNamespace>
     <AssemblyName>News</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/PartyMusicPlayer/PartyMusicPlayer.csproj
+++ b/MediaPortal/Source/UI/UiComponents/PartyMusicPlayer/PartyMusicPlayer.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/PartyMusicPlayer/PartyMusicPlayer.csproj
+++ b/MediaPortal/Source/UI/UiComponents/PartyMusicPlayer/PartyMusicPlayer.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/RemovableMediaManager/RemovableMediaManager.csproj
+++ b/MediaPortal/Source/UI/UiComponents/RemovableMediaManager/RemovableMediaManager.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/RemovableMediaManager/RemovableMediaManager.csproj
+++ b/MediaPortal/Source/UI/UiComponents/RemovableMediaManager/RemovableMediaManager.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/SkinBase/SkinBase.csproj
+++ b/MediaPortal/Source/UI/UiComponents/SkinBase/SkinBase.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/SkinBase/SkinBase.csproj
+++ b/MediaPortal/Source/UI/UiComponents/SkinBase/SkinBase.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/StatisticsRenderer/StatisticsRenderer.csproj
+++ b/MediaPortal/Source/UI/UiComponents/StatisticsRenderer/StatisticsRenderer.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.StatisticsRenderer</RootNamespace>
     <AssemblyName>StatisticsRenderer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/UiComponents/StatisticsRenderer/StatisticsRenderer.csproj
+++ b/MediaPortal/Source/UI/UiComponents/StatisticsRenderer/StatisticsRenderer.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.StatisticsRenderer</RootNamespace>
     <AssemblyName>StatisticsRenderer</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/MediaPortal/Source/UI/UiComponents/SystemStateMenu/SystemStateMenu.csproj
+++ b/MediaPortal/Source/UI/UiComponents/SystemStateMenu/SystemStateMenu.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SystemStateMenu</RootNamespace>
     <AssemblyName>SystemStateMenu</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/SystemStateMenu/SystemStateMenu.csproj
+++ b/MediaPortal/Source/UI/UiComponents/SystemStateMenu/SystemStateMenu.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.Plugins.SystemStateMenu</RootNamespace>
     <AssemblyName>SystemStateMenu</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/Utilities/Utilities.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Utilities/Utilities.csproj
@@ -16,7 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/Utilities/Utilities.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Utilities/Utilities.csproj
@@ -16,6 +16,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/MediaPortal/Source/UI/UiComponents/Weather/Weather.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Weather/Weather.csproj
@@ -17,6 +17,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/UiComponents/Weather/Weather.csproj
+++ b/MediaPortal/Source/UI/UiComponents/Weather/Weather.csproj
@@ -17,7 +17,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <NuGetPackageImportStamp>

--- a/MediaPortal/Source/UI/UiComponents/WifiConfiguration/WifiConfiguration.csproj
+++ b/MediaPortal/Source/UI/UiComponents/WifiConfiguration/WifiConfiguration.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.WifiConfiguration</RootNamespace>
     <AssemblyName>WifiConfiguration</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Source/UI/UiComponents/WifiConfiguration/WifiConfiguration.csproj
+++ b/MediaPortal/Source/UI/UiComponents/WifiConfiguration/WifiConfiguration.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MediaPortal.UiComponents.WifiConfiguration</RootNamespace>
     <AssemblyName>WifiConfiguration</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MediaPortal/Tests/Tests.Client/Tests.Client.csproj
+++ b/MediaPortal/Tests/Tests.Client/Tests.Client.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Tests.Client</RootNamespace>
     <AssemblyName>Tests.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/MediaPortal/Tests/Tests.Client/Tests.Client.csproj
+++ b/MediaPortal/Tests/Tests.Client/Tests.Client.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Tests.Client</RootNamespace>
     <AssemblyName>Tests.Client</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/MediaPortal/Tools/LogCollector/MediaPortal.LogCollector.csproj
+++ b/MediaPortal/Tools/LogCollector/MediaPortal.LogCollector.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>MediaPortal.LogCollector</RootNamespace>
     <AssemblyName>MP2-LogCollector</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>

--- a/MediaPortal/Tools/LogCollector/MediaPortal.LogCollector.csproj
+++ b/MediaPortal/Tools/LogCollector/MediaPortal.LogCollector.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>MediaPortal.LogCollector</RootNamespace>
     <AssemblyName>MP2-LogCollector</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>


### PR DESCRIPTION
A simple regex to add <RuntimeIdentifier>win</RuntimeIdentifier> to all of the csproj files. See [the issue on vs's tracker](https://developercommunity.visualstudio.com/content/problem/312180/projects-fail-to-build-in-1580-due-to-errors-from.html)